### PR TITLE
[Weekly Contest 402] [Seori] 6주차 3문제 풀이

### DIFF
--- a/Seori/Weekly Contest 402/3184. Count Pairs That Form a Complete Day I.py
+++ b/Seori/Weekly Contest 402/3184. Count Pairs That Form a Complete Day I.py
@@ -1,0 +1,9 @@
+class Solution:
+    def countCompleteDayPairs(self, hours: List[int]) -> int:
+        # [1] 만약 두 시간의 합이 24로 나누어 떨어진다면, 두 시간은 하루를 완성한다. If the sum of two hours is divisible by 24, the two hours complete a day.
+        answer = 0
+        for i in range(len(hours)):
+            for j in range(i + 1, len(hours)):
+                if not (hours[i] + hours[j]) % 24:
+                    answer += 1
+        return answer

--- a/Seori/Weekly Contest 402/3185. Count Pairs That Form a Complete Day II.py
+++ b/Seori/Weekly Contest 402/3185. Count Pairs That Form a Complete Day II.py
@@ -1,0 +1,13 @@
+from collections import Counter
+class Solution:
+    def countCompleteDayPairs(self, hours: List[int]) -> int:
+        counter = Counter(map(lambda x: x % 24, hours))
+        answer = 0
+        for i in range(0, 13):
+            # [1] 24로 나눈 나머지가 0이나 12인 경우, 조합으로 경우의 수를 구한다. If the remainder of division by 24 is 0 or 12, calculate the number of cases by combination.
+            if i == 0 or i == 12:
+                answer += int((counter[i] * (counter[i] - 1)) / 2)
+            # [2] 그 이외에는 24-i의 개수와 곱하여 경우의 수를 구한다. Otherwise, calculate the number of cases by multiplying the number of 24-i.
+            else:
+                answer += counter[i] * counter[24-i]
+        return answer

--- a/Seori/Weekly Contest 402/3186. Maximum Total Damage With Spell Casting.py
+++ b/Seori/Weekly Contest 402/3186. Maximum Total Damage With Spell Casting.py
@@ -1,0 +1,24 @@
+from collections import Counter
+class Solution:
+    def maximumTotalDamage(self, power: List[int]) -> int:
+        counter = Counter(power)
+        damages = sorted(list(counter.keys()))
+        N = len(damages)
+        dp = [0] * N    # dp는 i번째까지의 최대 데미지를 저장한다. dp stores the maximum damage until i-th.
+
+        dp[0] = damages[0] * counter[damages[0]]
+        for i in range(1, N):
+            damage = damages[i]
+
+            # [1] 오름차순 damages 배열에서 이전 1, 2, 3번째의 최대 데미지값을 가져온다. Get the maximum damage values of the previous 1, 2, 3 from the ascending damages array.
+            for j in range(1, 4):
+                if i-j >= 0 and damage - damages[i-j] > 2:
+                    dp[i] = max(dp[i], dp[i-j])
+
+            # [2] i번째 데미지값을 더해준다. Add the i-th damage value.
+            dp[i] += damage * counter[damage]
+
+            # [3] 이전 최대 데미지값과 비교하여 최대값을 저장한다. Compare with the previous maximum damage value and store the maximum value.
+            dp[i] = max(dp[i], dp[i-1])
+
+        return dp[N-1]


### PR DESCRIPTION
**3184. Count Pairs That Form a Complete Day I**
---
- 문제에서 주어진 대로 두 시간의 합을 24로 나누어 계산하여 답을 구했다.

**3185. Count Pairs That Form a Complete Day II**
---
- 첫 번째 제약조건 `hours.length`가 $5*10^5$ 이하이므로 앞의 문제처럼 2중 for문을 사용할 수 없었다.
- 두 번째 제약조건 `hours[i]`가 $10^9$ 이하이므로 `Counter`를 사용하되, 데이터를 더 간단하게 저장하는 방법을 고민했다.
- 모든 시간을 `24`로 나눈 나머지값만을 `Counter`에 기록하여 해결하였다.

**3186. Maximum Total Damage With Spell Casting**
---
- `power[i] - 2`부터 `power[i] + 2` 사이 범위에서 `spell`을 하나만 고르면서 최댓값을 찾는 문제이므로 `DP` 풀이를 떠올렸다.
- `set`과 `Counter`를 활용하여 범위가 큰 `power`를 간단하게 저장할 수 있었다.
- 주석의 [3]번 풀이는 잘 떠올리지 못했지만 반례를 검증하면서 도출해낼 수 있었다.