### PR TITLE
[Weekly Contest 403] [Gombang] 7주차 3문제 풀이

### DIFF
--- a/Gombang/Weekly Contest 403/3194_Minimum_Average_of_Smallest_and_Largest_Elements.cs
+++ b/Gombang/Weekly Contest 403/3194_Minimum_Average_of_Smallest_and_Largest_Elements.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+public class Solution
+{
+    public double MinimumAverage(int[] nums)
+    {
+        // 오름차순 정렬
+        Array.Sort(nums);
+
+        double result = double.MaxValue;
+        int left = 0;
+        int right = nums.Length - 1;
+
+        while (left < right)
+        {
+            double average = (nums[left] + nums[right]) / 2.0;
+            if (result > average)
+                result = average;
+
+            left++;
+            right--;
+        }
+
+        return result;
+    }
+}

--- a/Gombang/Weekly Contest 403/3195_Find_the_Minimum_Area_to_Cover_All_Ones_I.cs
+++ b/Gombang/Weekly Contest 403/3195_Find_the_Minimum_Area_to_Cover_All_Ones_I.cs
@@ -1,0 +1,34 @@
+﻿public class Solution
+{
+    public int MinimumArea(int[][] grid)
+    {
+
+        // 가로로 보았을 때, 1의 인덱스가 가장 작은 값과 가장 큰 값을 담을 변수
+        int horizontalFirstOneIndex = int.MaxValue;
+        int horizontalLastOneIndex = int.MinValue;
+
+        // 세로로 보았을 때, 1의 인덱스가 가장 작은 값과 가장 큰 값을 담을 변수
+        int verticalFirstOneIndex = int.MaxValue;
+        int verticalLastOneIndex = int.MinValue;
+
+        for (int i = 0; i < grid.Length; i++)
+        {
+            for (int j = 0; j < grid[0].Length; j++)
+            {
+                if (grid[i][j] == 1)
+                {
+                    if (horizontalFirstOneIndex > j) horizontalFirstOneIndex = j;
+                    if (horizontalLastOneIndex < j) horizontalLastOneIndex = j;
+
+                    if (verticalFirstOneIndex > i) verticalFirstOneIndex = i;
+                    if (verticalLastOneIndex < i) verticalLastOneIndex = i;
+                }
+            }
+        }
+
+        int width = horizontalLastOneIndex - horizontalFirstOneIndex + 1;
+        int height = verticalLastOneIndex - verticalFirstOneIndex + 1;
+
+        return width * height;
+    }
+}

--- a/Gombang/Weekly Contest 403/3196_Maximize_Total_Cost_of_Alternating_Subarrays.cs
+++ b/Gombang/Weekly Contest 403/3196_Maximize_Total_Cost_of_Alternating_Subarrays.cs
@@ -1,0 +1,34 @@
+﻿public class Solution
+{
+    public long MaximumTotalCost(int[] nums)
+    {
+        if (nums.Length == 1)
+            return nums[0];
+
+        int length = nums.Length;
+
+        // dp배열을 만들고 가장 작은 값으로 초기화.
+        long[] dp = new long[length];
+        for (int i = 0; i < length; i++)
+            dp[i] = long.MinValue;
+
+        // 0번째 인덱스와 1번째 인덱스는 수동으로 값 저장.
+        dp[0] = nums[0];
+
+        if (nums[1] < 0)
+            dp[1] = dp[0] + -1 * nums[1];
+        else
+            dp[1] = dp[0] + nums[1];
+
+        // 2번째 인덱스부터 dp계산 활용.
+        for (int i = 2; i < length; i++)
+        {
+            if (nums[i] < 0)
+                dp[i] = dp[i - 2] + nums[i - 1] + nums[i] * -1;
+
+            dp[i] = Math.Max(dp[i], dp[i - 1] + nums[i]);
+        }
+
+        return dp[length - 1];
+    }
+}


### PR DESCRIPTION
Q. Minimum Average of Smallest and Largest Elements
---
- 가장 작은 값과 가장 큰 값을 쌍으로 더해주는 방식이기에 정렬을 먼저 진행하였고, 쌍의 평균값을 계산하면서 그 값의 최솟값이 계속 업데이트 되도록 하는 방식으로 진행하였다. 
- 처음에는 nums길이의 절반에 해당하는 크기를 가진 배열을 만들어서 쌍의 평균값들을 해당 배열에 저장하는 방식으로 진행하였지만, 최솟값만 구해주면 되는 것이어서 조건을 통해 최솟값이 업데이트 되는 방식으로 코드를 수정하였습니다.

Q. Find the Minimum Area to Cover All Ones 1
---
- 어떻게 풀어야 될까를 계속 고민하다가 일단 사각형의 넓이를 구하기 위해서 필요한 것은 [가로길이]와 [세로길이]이므로 이 길이를 구하는 것에 초점을 맞추어 고민하였습니다. 
- 가로에 대해서 1이 존재하는 가장 작은 인덱스와 가장 큰 인덱스를 구할 수 있다면 그 차이를 통해 가로의 길이를 알아낼 수 있고 세로 또한 이 방식으로 세로의 길이를 알아낼 수 있기에 이 인덱스를 구하는 방식으로 진행하였습니다.

Q. Maximize Total Cost of Alternating Subarrays
---
- 문제를 이해하기가 어려워서 솔루션 중에 문제에 대해서 이해시켜주는 영상이 있기에 해당 영상을 참고하여 문제를 이해하였습니다.
- dp를 이용하여 문제를 풀었고, for루프를 돌리면서 **현재 인덱스에 해당하는 값이 음수일 때 -1을 곱해서 더한 값**과 **현재 인덱스에 해당하는 값을 SubArray로 처리하여 +로 바로 더한 값** 중 더 큰 값을 dp배열에 넣는 방식으로 풀이를 진행하였습니다.