### PR TITLE
[Weekly contest 406] [Gombang] 10주차 3문제 풀이

### DIFF
--- a/Gombang/Weekly Contest 406/3216_Lexicographically_Smallest_String_After_a_Swap.cs
+++ b/Gombang/Weekly Contest 406/3216_Lexicographically_Smallest_String_After_a_Swap.cs
@@ -1,0 +1,23 @@
+﻿public class Solution
+{
+    public string GetSmallestString(string s)
+    {
+        char[] charArray = s.ToCharArray();
+
+        for (int i = 1; i < charArray.Length; i++)
+        {
+            int num1 = int.Parse(charArray[i - 1].ToString());
+            int num2 = int.Parse(charArray[i].ToString());
+
+            if (num1 > num2 && (num1 + num2) % 2 == 0)
+            {
+                char temp = charArray[i];
+                charArray[i] = charArray[i - 1];
+                charArray[i - 1] = temp;
+                break;
+            }
+        }
+
+        return new string(charArray);
+    }
+}

--- a/Gombang/Weekly Contest 406/3217_Delete_Nodes_From_Linked_List_Present_in_Array.cs
+++ b/Gombang/Weekly Contest 406/3217_Delete_Nodes_From_Linked_List_Present_in_Array.cs
@@ -1,0 +1,63 @@
+﻿
+public class Solution
+{
+    public ListNode ModifiedList(int[] nums, ListNode head)
+    {
+        // value는 0이고 head를 nextNode로 하는 newHead노드 생성.
+        ListNode newHead = new ListNode(0, head);
+        ListNode prev = newHead;
+        ListNode curr = head;
+
+        //HashSet은 List와 동일한 구조를 가지고 있지만, 차이점은 중복 값을 허용하지 않는 컬렉션이다.
+        HashSet<int> hash = new HashSet<int>(nums);
+
+        while (curr != null)
+        {
+            if (hash.Contains(curr.val))
+                prev.next = curr.next;
+            else
+                prev = curr;
+
+            curr = curr.next;
+        }
+
+        return newHead.next;
+    }
+}
+
+// 첫 번째 풀이 : Time Limit Exceeded ( 577 / 582 testcases passed )
+// nums배열에 동일한 값이 많이 있을 경우에 대해서 문제가 발생.
+//public class Solution
+//{
+//    // Time Limit Exceeded
+//    public ListNode ModifiedList(int[] nums, ListNode head)
+//    {
+//        // value는 0이고 head를 nextNode로 하는 newHead노드 생성.
+//        ListNode newHead = new ListNode(0, head);
+//        ListNode prev = newHead;
+//        ListNode curr = head;
+
+//        while (curr != null)
+//        {
+//            bool found = false;
+//            foreach (int num in nums)
+//            {
+//                if (num == curr.val)
+//                {
+//                    prev.next = curr.next;
+//                    curr = prev.next;
+//                    found = true;
+//                    break;
+//                }
+//            }
+
+//            if (found == false)
+//            {
+//                prev = curr;
+//                curr = curr.next;
+//            }
+//        }
+
+//        return newHead.next;
+//    }
+//}

--- a/Gombang/Weekly Contest 406/3218_Minimum_Cost_for_Cutting_Cake_I.cs
+++ b/Gombang/Weekly Contest 406/3218_Minimum_Cost_for_Cutting_Cake_I.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+public class Solution
+{
+    // 가로로 한 번 자르게 되면 두 덩이가 생기게 되는데 이는 세로로 자르기 위해서는 두 번의 자르는 행위를 해야한다.
+    // 즉, 자르는 축을 기준으로 다른 축은 잘라야 하는 횟수가 계속해서 하나씩 증가한다는 것을 알 수 있다.
+
+    // 문제는 최소 비용을 구하는 것이므로, 큰 비용에 대해서 잘라야 하는 횟수가 적어야 한다.
+    // 즉, 내림차순 정렬을 통하여 먼저 큰 비용에 해당하는 값으로 자르는 행위를 진행한다.
+    public long MinimumCost(int m, int n, int[] horizontalCut, int[] verticalCut)
+    {
+        long minimumCost = 0;
+
+        // 내림 차순 정렬.
+        List<int> horizontalCutList = horizontalCut.OrderByDescending(num => num).ToList();
+        List<int> verticalCutList = verticalCut.OrderByDescending(num => num).ToList();
+
+        int horizontalLine = 1;
+        int verticalLine = 1;
+
+        int hArrayLength = horizontalCut.Length;
+        int vArrayLength = verticalCut.Length;
+        int hIndex = 0;
+        int vIndex = 0;
+
+        while (hIndex < horizontalCutList.Count || vIndex < verticalCutList.Count)
+        {
+            // 문제 조건에서 배열의 최소값은 1이므로, 0은 나올수 없는 값.
+            int hMax = hIndex < horizontalCutList.Count ? horizontalCutList[hIndex] : 0;
+            int vMax = vIndex < verticalCutList.Count ? verticalCutList[vIndex] : 0;
+
+            if (hMax >= vMax)
+            {
+                // 가로로 자르면 세로라인을 하나 증가시킴.
+                minimumCost += hMax * horizontalLine;
+                verticalLine++;
+                hIndex++;
+            }
+            else
+            {
+                // 세로로 자르면 가로라인을 하나 증가시킴.
+                minimumCost += vMax * verticalLine;
+                horizontalLine++;
+                vIndex++;
+            }
+        }
+
+        return minimumCost;
+    }
+}


### PR DESCRIPTION
Q. Lexicographically Smallest String After a Swap
---
- 처음에 문제를 보았을 때에는 스왑을 한 번만 진행한다는 내용을 확인하지 못하고 예시를 이해하려는데에 시간을 조금 쓰게 되었다. 그러다가 Discussion을 보니, 스왑을 한 번만 진행한다는 문구를 알려준 사람이 있어서 해당 방식으로 진행하게 되었습니다.

- string문자열의 각 문자들을 char배열로 새롭게 담아주고, (문제에서 요구한 방식대로) 사전순으로 처리하기 위해서 인접한 두 요소의 크기를 비교해가면서 앞에 있는 요소가 더 컸을 때, 두 요소의 Parity가 같은지를 검사하여 같다면 스왑하는 방식으로 진행하였습니다.

Q. Delete Nodes From Linked List Present in Array
---
- 처음에는 문제를 풀었으나, 해당 풀이 방법은 `nums` 배열에 노드에 대한 값이 있는지를 **nums배열을 순회하면서 체크하는 방식**으로 진행했었는데 `Time Limit Exceeded`가 발생하였습니다. 해당 테스트 케이스를 확인해보니 nums배열에 동일한 값이 정말 많이 있을 때에 대한 테스트 케이스였습니다.

- 그래서 해당 이슈를 수정하기 위해 `HashSet`이라는 컬렉션을 이용하게 되었습니다. HashSet 컬렉션은 List와 구조는 동일하지만 중복 값을 허용하지 않는 컬렉션입니다. 즉, 동일한 값이 들어있지 않은 List이기 때문에 해당 이슈를 통과할 수 있게 되었습니다.

Q. Minimum Cost for Cutting Cake I
---
- 처음에 문제를 이해하고 어떻게 풀어야 하는지에 대해서 감이 잡히지 않아서 솔루션을 참고하였습니다. 솔루션을 보면서 문제를 다시 천천히 이해해보니 크게 어려운 문제는 아니었구나라는 것을 보고 다시 문제를 풀기 시작하였습니다.

- 큰 비용에 대해서는 적게 더해져야 하는 문제이기 때문에, 일단 내림차순정렬을 먼저 진행하게 되었습니다.

- 이 문제의 특징은 **세로나 가로로 한 번 자르게 되면, 다음에 다른 축으로 잘라야 하는 횟수가 하나가 더 증가한다.** 라는 것을 토대로 알고리즘을 진행하였습니다.

- 하나 갸우뚱 했던 점이 있었는데, 원래 문제를 풀었던 방식은, 배열에 있는 요소를 리스트화하여 가로나 세로로 한 번 잘랐을 경우 해당 비용을 리스트에서 제거하는 방식으로 진행하였습니다. 제출을 해보니 `Time Limit Exceeded 에러`가 나게 되어 해당 테스트 케이스를 직접 추가해서 풀이를 해보려고 테스트 케이스를 추가했는데, 아무생각없이 Run을 돌려보니 해당 테스트 케이스가 통과되는 것을 확인할 수 있었습니다. 뭔가 Run을 통해서 돌렸을 때와 제출을 했을 때에 대해서는 다르게 동작하는 부분이 존재하는 구나를 생각하게된(?) 시간이 있었습니다.

- 제거하는 방식에서 타임 에러가 나게 되기 때문에, 인덱스를 통해서 비교하는 방식으로 수정하게 되었습니다.