### PR TITLE
[Weekly contest 407] [Gombang] 11주차 3문제 풀이

### DIFF
--- a/Gombang/Weekly Contest 407/3226_Number_of_Bit_Changes_to_Make_Two_Integers_Equal.cs
+++ b/Gombang/Weekly Contest 407/3226_Number_of_Bit_Changes_to_Make_Two_Integers_Equal.cs
@@ -1,0 +1,76 @@
+﻿// 두 번째 문제 풀이.
+// 솔루션을 확인해보니 비트 연산들을 이용하여 풀면 간단하게 풀이되는 것을 확인하여 해당 방식으로 다시 풀이.
+// xor연산을 하면 서로 다른 비트에 대해서만 1이라는 값을 갖게 되므로, 해당 1의 개수를 구하면 이 문제의 답이 된다.
+public class Solution
+{
+    public int MinChanges(int n, int k)
+    {
+        // n & k 를 했을 때 k가 나와야 한다. 그렇지 않으면 n의 값을 change하더라도 k값이 나올 수가 없음.
+        if ((n & k) != k) return -1;
+
+        int xor = n ^ k;
+        int count = 0;
+
+        // 1의 개수 확인하기
+        while (xor > 0)
+        {
+            count += xor & 1;
+            xor >>= 1;
+        }
+
+        return count;
+    }
+}
+
+
+// 첫 번째 문제 풀이.
+// 1. 직접 n과 k에 대해 이진수를 구한다.
+// 2. 두 이진수 중, 길이가 작은 이진수에 대해서 부족한 길이만큼 0으로 채우는 작업 진행.
+// 3. n에 대한 이진수를 기준으로, 0번째 인덱스부터 비교해가며 서로 다른 문자일 경우,
+//          1) 해당 문자가 1이면 +1
+//          2) 해당 문자가 0이면 문제에 의해 수정할 수 없으므로 -1 반환.
+
+public class Solution
+{
+    public int MinChanges(int n, int k)
+    {
+        int result = 0;
+
+        string nBinaryStr = GetBinaryNum(n).ToString();
+        string kBinaryStr = GetBinaryNum(k).ToString();
+
+        if (nBinaryStr.Length > kBinaryStr.Length)
+            kBinaryStr = kBinaryStr.PadLeft(nBinaryStr.Length, '0');
+        else
+            nBinaryStr = nBinaryStr.PadLeft(kBinaryStr.Length, '0');
+
+        for (int i = 0; i < nBinaryStr.Length; i++)
+        {
+            if (nBinaryStr[i] == kBinaryStr[i])
+                continue;
+
+            if (nBinaryStr[i] == '1')
+                result++;
+
+            if (nBinaryStr[i] == '0')
+                return -1;
+        }
+
+        return result;
+    }
+
+    public ulong GetBinaryNum(int num)
+    {
+        ulong binaryNum = 0;
+        ulong place = 1;
+        while (num > 0)
+        {
+            ulong remainder = (ulong)(num % 2);
+            binaryNum += remainder * place;
+            num /= 2;
+            place *= 10;
+        }
+
+        return binaryNum;
+    }
+}

--- a/Gombang/Weekly Contest 407/3227_Vowels_Game_in_a_String.cs
+++ b/Gombang/Weekly Contest 407/3227_Vowels_Game_in_a_String.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+public class Solution
+{
+    public bool DoesAliceWin(string s)
+    {
+        List<char> vowels = new List<char>()
+        {
+            'a', 'e', 'i', 'o', 'u'
+        };
+
+        int vowelCount = 0;
+
+        for (int i = 0; i < s.Length; i++)
+        {
+            if (vowels.Contains(s[i]))
+                vowelCount++;
+        }
+
+        return vowelCount > 0 ? true : false;
+    }
+}

--- a/Gombang/Weekly Contest 407/3228_Maximum_Number_of_Operations_to_Move_Ones_to_the_End.cs
+++ b/Gombang/Weekly Contest 407/3228_Maximum_Number_of_Operations_to_Move_Ones_to_the_End.cs
@@ -1,0 +1,22 @@
+﻿public class Solution
+{
+    public int MaxOperations(string s)
+    {
+        int oneNumberCount = 0;
+        int answer = 0;
+
+        for (int i = 0; i < s.Length; i++)
+        {
+            if (s[i] == '0')
+            {
+                answer += oneNumberCount;
+                while (i < s.Length && s[i] != '1')
+                {
+                    i++;
+                }
+            }
+            oneNumberCount++;
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
Q. Number of Bit Changes to Make Two Integers Equal
---
- 처음에 문제를 보고 접근했던 방식은, 해당 값에 대해서 직접 이진수를 구하고 문자열화 한 후 동일한 인덱스 위치에 해당하는 문자를 비교하는 방식으로 진행하였습니다. 처음에는 이진수 값을 구할 때 int형과 long형의 범위를 벗어나는 문제가 발생하여 ulong형으로 풀이를 진행하였습니다. 

- 솔루션을 확인해보니 비트연산을 이용해서 문제 풀이를 한 것을 보고 훨씬 쉽게 문제를 풀 수 있겠다!는 생각을 하게 되어 해당 방식으로 다시 풀이를 진행하게 되었습니다. 오랜만에 비트 연산에 대해서 개념 공부도 다시 할 수 있는 시간을 갖게 되었습니다.

Q. Vowels Game in a String
---
- 이 문제는 내가 문제를 제대로 이해한 것이 맞나? 싶은 생각을 가지고 그대로 풀었는데 너무 허무하게 풀려서 조금 당황한 문제였습니다. 

- 앨리스와 밥이 번갈아가면서 앨리스는 모음을 홀수개 지울 수 있고 밥은 짝수개를 지울 수 있는데, 앨리스가 먼저 시작하므로 최대한 많은 홀수개를 지워서 밥은 아예 지울수 없는 짝수개(0개)를 계속 유도하기만 하면 엘리스의 승리이므로, 이는 모음의 개수가 하나 이상만 있으면 무조건 이길 수 있는 경우가 된다. 따라서, 모음의 개수를 모두 세서 1개 이상 있으면 true를 반환하고 그렇지 않으면 false를 반환하는 식으로 문제를 풀이하였습니다. 

- 그런데 다시 생각해보니 문자열의 모음의 개수를 모두 세는 것보다, **순회하다가 모음을 하나라도 만나는 순간 true를 반환하고 반복문이 종료되면 false를 반환**해도 됐을 것 같다.

Maximum Number of Operations to Move Ones to the End
---
- 해당 문제는 풀이에 대한 감을 잡지 못하여, 솔루션을 보고 진행하였습니다. 처음에는 솔루션을 봐도 왜 이런 알고리즘이 나왔는지를 이해하지 못했었는데 다시 차근차근 코드를 보니 이해를 할 수 있었습니다.

- '1'이라는 문자는 뒤에 나오는 '0' 이라는 문자와 위치를 바꿀 수 있다는 개념을 기준으로, 반복문을 진행하면서 '1'이 나올때마다 개수를 카운팅하고, '0'을 만나는 순간 현재까지 카운팅된 1의 개수를 정답에 더해줍니다. **더해준다라는 과정**은 현재 만난 '0'과 지금까지 나온 모든 '1'들의 위치를 바꾼다는 개념이 되며, for문 안에 있는 while문을 통해 연속으로 나오는 0들을 모두 건너뛰기 위해 i값을 증가시킵니다. 이 과정을 반복하여 '0'이 나올 때마다 카운팅 되어 있던 1의 개수들을 모두 더해주면 모든 1의 위치를 맨 오른쪽으로 이동시킨 상태로 완료됩니다.

- 위의 흐름을 나중에 다시 똑같이 이해할 수 있는지 나중에 다시 한 번 문제를 풀어보면 좋을 것 같다.