### PR TITLE
[Weekly contest 410] [Lucy] 14주차 2문제 풀이

### DIFF
--- a/Lucy/Weekly Contest 410/3248_Snake_in_Matrix.js
+++ b/Lucy/Weekly Contest 410/3248_Snake_in_Matrix.js
@@ -1,0 +1,71 @@
+/**
+ * 3248. Snake in Matrix
+ * url: https://leetcode.com/problems/snake-in-matrix/
+ *
+ * topic: Array, String, Simulation
+ * difficulty: Easy
+ * date: 2024.08.21(WED)~
+ */
+
+const COMMANDS = Object.freeze({
+  UP: "UP",
+  DOWN: "DOWN",
+  RIGHT: "RIGHT",
+  LEFT: "LEFT",
+});
+const MOVEMENT = Object.freeze({
+  UP: [-1, 0],
+  DOWN: [1, 0],
+  LEFT: [0, -1],
+  RIGHT: [0, 1],
+});
+
+/**
+ * @param {number} n
+ * @param {string[]} commands
+ * @return {number}
+ */
+var finalPositionOfSnake = function (n, commands) {
+  const grid = Array.from({ length: n }, (_) => new Array(n).fill(0));
+  // 1. grid 초기화
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      grid[i][j] = i * n + j;
+    }
+  }
+
+  // 2. 명령어에 따라 이동
+  let cell = [0, 0];
+  commands.forEach((cmd) => {
+    let nx = 0,
+      ny = 0;
+
+    switch (cmd) {
+      case COMMANDS.UP:
+        nx = MOVEMENT.UP[0];
+        ny = MOVEMENT.UP[1];
+        break;
+      case COMMANDS.DOWN:
+        nx = MOVEMENT.DOWN[0];
+        ny = MOVEMENT.DOWN[1];
+        break;
+      case COMMANDS.LEFT:
+        nx = MOVEMENT.LEFT[0];
+        ny = MOVEMENT.LEFT[1];
+        break;
+      case COMMANDS.RIGHT:
+        nx = MOVEMENT.RIGHT[0];
+        ny = MOVEMENT.RIGHT[1];
+        break;
+    }
+
+    cell[0] += nx;
+    cell[1] += ny;
+  });
+
+  const [x, y] = cell;
+  return grid[x][y];
+};
+
+console.log(finalPositionOfSnake(2, ["RIGHT", "DOWN"]));
+console.log(finalPositionOfSnake(3, ["DOWN", "RIGHT", "UP"]));

--- a/Lucy/Weekly Contest 410/3249_Count_the_Number_of_Good_Nodes.js
+++ b/Lucy/Weekly Contest 410/3249_Count_the_Number_of_Good_Nodes.js
@@ -1,0 +1,101 @@
+/**
+ * 3249. Count the Number of Good Nodes
+ * url: https://leetcode.com/problems/count-the-number-of-good-nodes/
+ *
+ * topic: Tree, Depth-First-Search
+ * difficulty: Medium
+ * date: 2024.08.21(WED)~
+ */
+
+/**
+ * @param {number[][]} edges
+ * @return {number}
+ */
+var countGoodNodes = function (edges) {
+  const tree = {};
+
+  // 인접 리스트 형태로 생성
+  for (const [u, v] of edges) {
+    !tree[u] && (tree[u] = []);
+    tree[u].push(v);
+
+    !tree[v] && (tree[v] = []);
+    tree[v].push(u);
+  }
+
+  let goodNodes = 0;
+
+  const dfs = (node, parent) => {
+    let size = 1;
+    // 자식 서브 트리의 크기를 저장하는 배열
+    const sizes = [];
+
+    // 자식 노드 순회
+    for (const neighbor of tree[node]) {
+      // 부모 노드로 역방향 탐색을 방지하기 위한 조건
+      if (neighbor === parent) {
+        continue;
+      }
+
+      // 재귀 호출을 하여 서브 트리의 크기 계산
+      const subSize = dfs(neighbor, node);
+      sizes.push(subSize);
+      // 현재 노드가 포함된 전체 서브트리의 크기를 계산
+      size += subSize;
+    }
+
+    // 자식 노드 순회 후, good node 판별
+    // Set collection을 사용해서 size가 1개 이하면 자식 서브트리의 크기들이 모두 동일하다는 뜻!
+    if (new Set(sizes).size <= 1) {
+      goodNodes += 1;
+    }
+
+    // 서브트리 크기 반환
+    return size;
+  };
+
+  // dfs 시작, 루트 노드를 인자 값으로 설정
+  dfs(0, -1);
+
+  // goodNodes들 카운트한 값 반환
+  return goodNodes;
+};
+
+console.log(
+  countGoodNodes([
+    [0, 1],
+    [0, 2],
+    [1, 3],
+    [1, 4],
+    [2, 5],
+    [2, 6],
+  ])
+);
+console.log(
+  countGoodNodes([
+    [0, 1],
+    [1, 2],
+    [2, 3],
+    [3, 4],
+    [0, 5],
+    [1, 6],
+    [2, 7],
+    [3, 8],
+  ])
+);
+console.log(
+  countGoodNodes([
+    [0, 1],
+    [1, 2],
+    [1, 3],
+    [1, 4],
+    [0, 5],
+    [5, 6],
+    [6, 7],
+    [7, 8],
+    [0, 9],
+    [9, 10],
+    [9, 12],
+    [10, 11],
+  ])
+);


### PR DESCRIPTION
> 프로젝트 캠프 2주 동안은 교육 듣는데 9시부터 오후 6시까지 듣는게 생각보다 힘드네요...! 교육 들으면서 그동안 배웠던 리액트랑 타입스크립트 복습도 되고 놓치고 있던 개념들을 공부할 수 있어서 좋네요. 근데 알고리즘 스터디 우선순위를 낮추다 보니...계속 밀렸네요. 다음에는 밀리지 않도록 시간 분배 잘 해보도록 하겠습니다! 이번 주 문제 풀이도 수고하셨습니다!

# Q. Snake in Matrix
- topic: Array, String, Simulation
- difficulty: Easy
- review
  - 문제에 나온 공식((i * n) + j)를 사용하여 grid 라는 n * n 배열을 생성 및 초기화 한다.
  - commands 배열을 Array.prototype.forEach() 메서드를 사용하여 순회하면서 명령어에 맞게 x, y 좌표 값을 이동 시킨다. 이동 시킨 값들은 cell 이라는 변수에 담는다.
  - commands 배열의 순회가 끝난 후 cell에 담긴 x, y 좌표를 꺼내서 grid[x][y] 요소 값을 반환한다.

# Q. Count the Number of Good Nodes
- topic: Tree, Depth-First-Search
- difficulty: Medium
- review
  - 문제를 읽었을 때, 이해가 가지 않았다. 문제 설명이 이해하기 어렵게 되어있었던 거 같아 ChatGPT에게 이해시켜달라고 부탁했다. 이 문제는 각 노드의 서브트리의 크기를 계산한 후, 각 노드의 서브트리의 크기가 동일한 경우를 goodNodes 라고 부른다. 그 goodNodes들의 갯수를 구하는 문제였다.
  - 인접 리스트를 사용해서 트리를 표현하는 것까지는 이해가 갔지만 dfs 알고리즘을 어떻게 적용해야할지 고민했다. 오랜만에 사용하는 알고리즘이라 다 까먹어서 ChatGPT의 도움을 받아 풀이할 수 있었다. 서브트리의 크기를 저장하는 변수 size, 자식 서브트리의 크기를 저장하는 배열 sizes 를 생성 및 초기화한다. for of문을 사용하여 자식 노드를 순회하며 그 자식 노드들의 서브트리의 크기를 dfs함수를 재귀호출하여 알아낸다. 계산된 자식 노드의 서브트리의 값을 sizes 배열에 push하고 size 변수에 더한다.
  - 모든 자식 노드를 순회하고 나면 Set 자료구조를 사용하여 sizes 배열의 중복 값을 제거한 후의 sizes 크기를 계산하여 1이하이면 goodNodes로 판단하여 goodNodes 변수의 값을 1 증가한다.
  - 마지막으로 goodNodes의 값을 반환한다.
  - dfs 알고리즘 문제 혼자서 풀 수 있도록 쉬운 문제부터 다시 공부해 봐야겠다.