### PR TITLE
[Weekly contest 411] [Gombang] 15주차 2문제 풀이

### DIFF
--- a/Gombang/Weekly Contest 411/3258_Count_Substrings_That_Satisfy_K-Constraint_I.cs
+++ b/Gombang/Weekly Contest 411/3258_Count_Substrings_That_Satisfy_K-Constraint_I.cs
@@ -1,0 +1,31 @@
+﻿public class Solution
+{
+	public int CountKConstraintSubstrings(string s, int k)
+	{
+		int result = 0;
+		int leftIndex = 0;
+
+		while (leftIndex < s.Length)
+		{
+			int zeroCnt = 0;
+			int oneCnt = 0;
+
+			for (int i = leftIndex; i < s.Length; i++)
+			{
+				if (s[i] == '0')
+					zeroCnt++;
+				else
+					oneCnt++;
+
+				if (zeroCnt <= k || oneCnt <= k)
+					result++;
+				else
+					break;
+			}
+
+			leftIndex++;
+		}
+
+		return result;
+	}
+}

--- a/Gombang/Weekly Contest 411/3259_Maximum_Energy_Boost_From_Two_Drinks.cs
+++ b/Gombang/Weekly Contest 411/3259_Maximum_Energy_Boost_From_Two_Drinks.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+public class Solution
+{
+	public long MaxEnergyBoost(int[] energyDrinkA, int[] energyDrinkB)
+	{
+		// dpA와 dpB라는 배열을 사용하여 현재 index까지 누적되는 최대값을 저장.
+		int n = energyDrinkA.Length;
+		long[] dpA = new long[n];
+		long[] dpB = new long[n];
+
+		dpA[0] = energyDrinkA[0];
+		dpB[0] = energyDrinkB[0];
+		dpA[1] = energyDrinkA[0] + energyDrinkA[1];
+		dpB[1] = energyDrinkB[0] + energyDrinkB[1];
+
+		for (int i = 2; i < n; i++)
+		{
+			// dpA[i-1]와 dpB[i-2]중 더 큰 값을 기준으로 energyDrinkA[i]를 더해서 dpA의 현재 인덱스에 저장.
+			dpA[i] = Math.Max(dpA[i - 1] , dpB[i - 2]) + energyDrinkA[i];
+			dpB[i] = Math.Max(dpB[i - 1] , dpA[i - 2]) + energyDrinkB[i];
+		}
+
+		return Math.Max(dpA[n - 1], dpB[n - 1]);
+	}
+}


### PR DESCRIPTION
Q. Count Substrings That Satisfy K-Constraint I
---
- 해당 문제를 처음 봤을 때는 0이나 1이나 최대 k개만큼만 존재할 수 있다는 것에 대해서 잘 이해하지 못하여 좀 헤매게 되었습니다. 그래도 계속 보다보니 예시에 대해서 이해할 수 있게 되었습니다.

- 앞에서부터 차례대로 1과 0의 개수를 카운팅해가며 1이나 0이 k개가 초과되면 다음 카운팅으로 넘어가도록 처리하였습니다. 

- 처음 문제를 이해하는 부분을 제외하고는 큰 어려움은 없었던 문제였습니다.

Q. Maximum Energy Boost From Two Drinks
---
- 문제를 보고 dp문제일 것이다라는 생각은 갖게 되었는데 어떤 식으로 식을 세워야 될지에 대해서 많은 고민을 갖게 되었습니다.

- A의 드링크를 마시다가 B의 드링크를 마시기 위해서는 1시간 후에 마실 수 있으며, 이 1시간은 하나의 인덱스를 건너 뛰게 된다는 것인데, 건너 뛰는 것을 어떻게 판단하고 처리할 수 있는지에 대해서 계속 고민을 해봤는데 마땅히 접근방법이 떠오르지가 않았습니다. 결국, 솔루션을 참고하게 되었고 해당 솔루션을 보니 어떤 식으로 문제를 풀어야 하는지를 알 수 있게 되었고 해당 방식으로 문제를 풀이하게 되었습니다.

- dp문제는 식을 세우기 전까지는 굉장히 난해한데, 식이 세워지면 참 간단한 알고리즘문제가 된다는게.. 앞으로도 많은 연습이 필요할 것 같다...