### PR TITLE
[Weekly Contest 412] [Seori] 16주차 3문제 풀이

### DIFF
--- a/Seori/Weekly Contest 412/3264. Final Array State After K Multiplication Operations I.py
+++ b/Seori/Weekly Contest 412/3264. Final Array State After K Multiplication Operations I.py
@@ -1,0 +1,8 @@
+class Solution:
+    def getFinalState(self, nums: List[int], k: int, multiplier: int) -> List[int]:
+        # [1] 연산을 k번 반복한다. Repeat the operation for k times.
+        for _ in range(k):
+            # [2] 최소값의 인덱스를 찾아 multiplier를 곱한다. Find the index of the minimum value and multiply it by the multiplier.
+            index_minV = nums.index(min(nums))
+            nums[index_minV] *= multiplier
+        return nums

--- a/Seori/Weekly Contest 412/3265. Count Almost Equal Pairs I.py
+++ b/Seori/Weekly Contest 412/3265. Count Almost Equal Pairs I.py
@@ -1,0 +1,55 @@
+class Solution:
+    def countPairs(self, nums: List[int]) -> int:
+
+        # [A] 두 수가 Almost Equal인지 확인하는 함수 check를 정의한다.
+        #     Define a function check to check if two numbers are Almost Equal.
+        def check(longer: int, shorter: int) -> int:
+
+            # [A-1] 앞에 0을 더해서 두 수의 길이를 맞춘다. Add 0s in front to match the length of two numbers.
+            longer, shorter = str(longer), str(shorter)
+            length_longer = len(longer)
+            while length_longer > len(shorter):
+                shorter = '0' + shorter
+            
+            # [A-2] 두 수가 같다면 비교할 필요가 없다. If two numbers are the same, no need to compare.
+            if longer == shorter:
+                return 1
+            
+            # [A-3] 길이가 2인 경우, 두 수가 대칭인지 확인한다. If the length is 2, check if two numbers are symmetric.
+            elif length_longer == 2:
+                if longer == shorter[::-1]:
+                    return 1
+            
+            # [A-4] 두 수의 다른 숫자가 2개이고, 서로 위치가 바뀌었을 때 같다면 Almost Equal이다.
+            #       If two numbers have two different numbers and are the same when their positions are swapped, they are Almost Equal.
+            else:
+                not_equal = 0
+                index_first, index_second = 0, 0
+                for k in range(length_longer):
+                    if longer[k] != shorter[k]:
+                        if not_equal == 0:
+                            not_equal = 1
+                            index_first = k
+                        elif not_equal == 1:
+                            not_equal = 2
+                            index_second = k
+                        else:
+                            return 0
+
+                if index_second and (longer[index_first] == shorter[index_second] and longer[index_second] == shorter[index_first]):
+                    return 1
+            
+            return 0
+    
+        # [1] nums의 모든 조합을 비교하여 Almost Equal인 쌍의 개수를 반환한다. Compare all combinations of nums and return the number of Almost Equal pairs.
+        result = 0
+        n = len(nums)
+        for i in range(n-1):
+            for j in range(i+1, n):
+                longer, shorter = nums[i], nums[j]
+                if nums[j] >= nums[i]:
+                    longer, shorter = nums[j], nums[i]
+                
+                result += check(longer, shorter)
+
+        return result

--- a/Seori/Weekly Contest 412/3266. Final Array State After K Multiplication Operations II.py
+++ b/Seori/Weekly Contest 412/3266. Final Array State After K Multiplication Operations II.py
@@ -1,3 +1,23 @@
+# 틀렸던 풀이 방법
+class Solution:
+    def getFinalState(self, nums: List[int], k: int, multiplier: int) -> List[int]:
+        MODULO = 10 ** 9 + 7
+        heap_nums = []
+        n = len(nums)
+        for i in range(n):
+            heapq.heappush(heap_nums, (nums[i], i))
+        
+        for _ in range(k):
+            heapq.heappushpop(heap_nums, (heap_nums[0][0] * multiplier, heap_nums[0][1]))
+        
+        result = [0] * n
+        for i in range(n):
+            num, index = heapq.heappop(heap_nums)
+            result[index] = num % MODULO
+        return result
+
+
+# 모범 답안 풀이 방법
 class Solution:
     def getFinalState(self, nums: List[int], k: int, multiplier: int) -> List[int]:
         

--- a/Seori/Weekly Contest 412/3266. Final Array State After K Multiplication Operations II.py
+++ b/Seori/Weekly Contest 412/3266. Final Array State After K Multiplication Operations II.py
@@ -1,0 +1,50 @@
+class Solution:
+    def getFinalState(self, nums: List[int], k: int, multiplier: int) -> List[int]:
+        
+        # [1] multiplier가 1인 경우, nums를 그대로 반환한다. If multiplier is 1, return nums as it is.
+        if multiplier == 1:
+            return nums
+
+        # [2] nums의 원소를 인덱스와 함께 heap_nums에 저장한다. Store the elements of nums in heap_nums with their index.
+        MODULO = 10 ** 9 + 7
+        heap_nums = []
+        n = len(nums)
+        for i, num in enumerate(nums):
+            heapq.heappush(heap_nums, (num, i))
+       
+        ''' 
+        k의 범위가 10^9 이하이므로, k번 반복하면 시간초과가 발생한다. 따라서 규칙을 찾아야 한다!
+        Since the range of k is less than 10^9, it will cause a timeout error if repeated k times. Therefore, we need to find a rule!
+        '''
+        # [3] nums의 원소 중 최대값이 가장 작은 수가 될 때까지 multiply 연산을 수행한다. Perform multiply operations until the maximum value of nums becomes the smallest.
+        largest = max(nums)
+        while k:
+            num, index = heapq.heappop(heap_nums)
+            if num == largest:
+                heapq.heappush(heap_nums, (num, index))
+                break
+            num *= multiplier
+            nums[index] = num
+            heapq.heappush(heap_nums, (num, index))
+            k -= 1
+
+        # [4] [3]에서 최대값에 도달했다면 이후의 연산은 반복성을 갖는다. 반복되는 순서대로 orders에 인덱스를 저장한다.
+        #     If the maximum value is reached in [3], the subsequent operations are repetitive. Save the index in orders in the order of repetition.
+        orders = []
+        while len(heap_nums):
+            orders.append(heapq.heappop(heap_nums)[1])
+        
+        # [5] cycles는 전체 연산이 반복될 횟수, leftovers는 남은 연산 횟수이다. 나머지 연산부터 처리한다.
+        #     cycles is the number of times the entire operation is repeated, and leftovers is the remaining number of operations. Process the remaining operations first.
+        cycles = k // len(orders)
+        leftovers = k % len(orders)        
+        for i in range(leftovers):
+            nums[orders[i]] *= multiplier
+        
+        # [6] 마지막으로 반복되는 cycles만큼 nums 전체에 multiplier를 곱하고 MODULO로 나눈 나머지를 반환한다. 이 때 pow 연산에서도 수가 너무 커지면 TLE가 발생하므로 MODULO로 나눈다.
+        #     Finally, multiply the entire nums by multiplier for the number of cycles repeated, and return the remainder divided by MODULO. If the number becomes too large in the pow operation, it will cause TLE, so divide it by MODULO.
+        for i in range(n):
+            nums[i] *= pow(multiplier, cycles, MODULO)
+            nums[i] %= MODULO
+
+        return nums


### PR DESCRIPTION
**3264. Final Array State After K Multiplication Operations I**
---
- 반복문과 인덱스를 활용하여 간단하게 풀었다.

**3265. Count Almost Equal Pairs I**
---
- 예제에서 숫자 앞에 `0`을 붙이는 예시가 있었기 때문에 바로 문자열을 활용하자는 생각으로 풀었다.
- 긴 숫자에 맞춰 짧은 숫자에 `0`을 붙이고, 앞에서부터 두 수의 자리수를 비교하기 시작했다.
- 문제가 어렵다기보다 `[A-2]`부터 `[A-4]`까지 경우의 수를 나누는 데 시간이 많이 들어간 문제였다.

**3266. Final Array State After K Multiplication Operations II**
---
- 자꾸 3번째 문제도 `Hard` 난이도인걸 보면 LeetCode의 트렌드가 바뀌었나 싶다.
- 문제를 읽자마자 스터디에서 공부했던 `Heap` 구조를 사용할 수 있지 않을까 싶어 바로 착수했다.
- 첫 번째 풀이에 실패했던 원인은 너무 자료구조에만 집착했다. `heapq` 모듈을 사용하여 풀이를 설계했으나, 정작 `k`의 범위를 신경쓰지 못했다. `k`의 범위가 너무 컸기 때문에 반복문을 돌리는 시점에 이미 너무 오래 걸렸다.
- `Hint`에서 문제에 규칙이 있음을 암시한다. 규칙을 찾아 `k`의 연산 횟수를 대폭 줄이는 것이 핵심이었다.
- `[6]` 계산을 하기 위해서 `[3]`과 `[5]`의 전처리를 해준다고 보면 이해에 도움이 될 것 같다.
- 그리고 `[6]` 부분에서도, 숫자가 너무 커지면 시간초과가 발생했어서 계산 중간에도 `MODULO` 나머지 연산 추가했더니 통과했다!