### PR TITLE
[Weekly Contest 413] [Seori] 17주차 2문제 풀이

### DIFF
--- a/Seori/Weekly Contest 413/3274. Check if Two Chessboard Squares Have the Same Color.py
+++ b/Seori/Weekly Contest 413/3274. Check if Two Chessboard Squares Have the Same Color.py
@@ -1,0 +1,5 @@
+class Solution:
+    def checkTwoChessboards(self, coordinate1: str, coordinate2: str) -> bool:
+        # 좌표의 앞뒤 합이 짝수이면 검정, 홀수이면 흰색이다. 따라서 두 좌표의 합이 짝수이면 같은 색이다.
+        # If the sum of the coordinates is even, it is black, and if it is odd, it is white. Therefore, if the sum of two coordinates is even, they are the same color.
+        return not (ord(coordinate1[0]) + int(coordinate1[1]) + ord(coordinate2[0]) + int(coordinate2[1])) % 2

--- a/Seori/Weekly Contest 413/3275. K-th Nearest Obstacle Queries.py
+++ b/Seori/Weekly Contest 413/3275. K-th Nearest Obstacle Queries.py
@@ -1,0 +1,21 @@
+class Solution:
+    def resultsArray(self, queries: List[List[int]], k: int) -> List[int]:
+        result = []
+        distance_list = []
+
+        # [1] heap 자료구조를 사용하여 장애물의 거리 정보를 저장한다. Use the heap data structure to store the distance information of obstacles.
+        for i in range(len(queries)):
+            distance = abs(queries[i][0]) + abs(queries[i][1])
+            heapq.heappush(distance_list, -distance)
+
+            # [2] 장애물이 k개 미만인 경우 -1을 반환한다. If there are less than k obstacles, return -1.
+            if i < k - 1:
+                result.append(-1)
+
+            # [3] 장애물이 k개 이상일 때, 힙의 최대값을 유지하면서 결과를 반환한다. When there are more than k obstacles, return the result while maintaining the maximum value of the heap.
+            else:
+                if i > k - 1:
+                    heapq.heappop(distance_list)
+                result.append(-distance_list[0])
+        return result
+            


### PR DESCRIPTION
> 이번 주 사내 알고리즘 대회 다녀왔습니다! 예고한 대로 무척 어려웠지만 재밌었어요 ㅎㅎ 총 4문제였는데 1등이 3문제, 2등이 2문제... 나머지는 1번 문제를 빨리 푼 순서대로 순위가 갈렸습니다. 백준 플래 문제는 참 어렵더라구요ㅠㅠ 실력이 오르면 LeetCode contest도 시간에 맞춰서 참가해봤으면 합니다.

**3274. Check if Two Chessboard Squares Have the Same Color**
---
- ASCII 코드를 활용하여 체스판 색깔의 규칙을 찾았다.
- 괜히 도전정신이 생겨 숏코딩에 도전해봤다.

**3275. K-th Nearest Obstacle Queries**
---
- 주어지는 `queries`의 길이마다 비교 연산이 필요했는데, 지난 번과 마찬가지로 `heap`을 활용하면 되겠다는 생각이 들었다.
- 파이썬의 기본 `heapq`는 최대 힙이므로 메서드 활용을 용이하게 하려고 `-`를 붙여 최소 힙을 만들어 활용했다.