### PR TITLE
[프로그래머스+LeetCode 75] [Gombang] 25년 6주차 3문제 풀이

### DIFF
--- a/Gombang/Programmers/택배 배달과 수거하기.cpp
+++ b/Gombang/Programmers/택배 배달과 수거하기.cpp
@@ -1,0 +1,74 @@
+#include <string>
+#include <vector>
+
+using namespace std;
+
+// 벡터에서 역순으로 체크하여 1이 아닌 인덱스를 찾는 함수.
+int findFirstCheckIndex(vector<int>& vec)
+{
+    int firstCheckIndex = 0;
+
+    for (int i = vec.size() - 1; i >= 0; i--)
+    {
+        if (vec[i] != 0)
+        {
+            firstCheckIndex = i;
+            break;
+        }
+    }
+
+    return firstCheckIndex;
+}
+
+// 벡터에 대해서 특정 인덱스부터 역순으로 탐색하여 cap만큼 감소하기 위한 함수.
+void Process(vector<int>& vec, int& nextIndex, int cap)
+{
+    int accumulatedNum = 0;
+    for (int i = nextIndex; i >= 0; i--)
+    {
+        nextIndex = i;
+        if (accumulatedNum + vec[i] <= cap)
+        {
+            accumulatedNum += vec[i];
+            vec[i] = 0;
+        }
+        else
+        {
+            vec[i] -= cap - accumulatedNum;
+            break;
+        }
+    }
+}
+
+long long solution(int cap, int n, vector<int> deliveries, vector<int> pickups) {
+    long long answer = 0;
+
+    // 배달 및 수거 해야할 맨뒤의 인덱스를 찾는 과정.
+    int nextDeliveryIndex = findFirstCheckIndex(deliveries);
+    int nextPickupIndex = findFirstCheckIndex(pickups);
+
+    // Test Case 2번.
+    // 모든 집들에 대해서 아무런 배달과 수거를 하지 않아도 된다면 바로 종료.
+    if (nextDeliveryIndex == 0 && deliveries[0] == 0 &&
+        nextPickupIndex == 0 && pickups[0] == 0)
+        return answer;
+
+    while (true)
+    {
+        // 가장 먼 지점부터 배달 또는 수거를 하기 위해서 진행.
+        int moveDistance = nextDeliveryIndex > nextPickupIndex ?
+            nextDeliveryIndex + 1 : nextPickupIndex + 1;
+
+        Process(deliveries, nextDeliveryIndex, cap);
+        Process(pickups, nextPickupIndex, cap);
+
+        answer += moveDistance;
+
+        // 모든 집들에 대해서 더이상 배달과 수거를 하지 않아도 된다면 바로 종료.
+        if (nextDeliveryIndex == 0 && deliveries[0] == 0 &&
+            nextPickupIndex == 0 && pickups[0] == 0)
+            break;
+    }
+
+    return answer * 2;
+}

--- a/Gombang/[LeetCode75] - [Queue]/649_Dota2_Senate.cpp
+++ b/Gombang/[LeetCode75] - [Queue]/649_Dota2_Senate.cpp
@@ -1,0 +1,29 @@
+class Solution {
+public:
+    string predictPartyVictory(string senate) {
+        queue<int> radiant_queue, dire_queue;
+        int n = senate.size();
+
+        for (int i = 0; i < n; i++) {
+            if (senate[i] == 'R')
+                radiant_queue.push(i);
+            else
+                dire_queue.push(i);
+        }
+
+        while (!radiant_queue.empty() && !dire_queue.empty()) {
+            int radiantIndex = radiant_queue.front();
+            radiant_queue.pop();
+
+            int direIndex = dire_queue.front();
+            dire_queue.pop();
+
+            if (radiantIndex < direIndex)
+                radiant_queue.push(radiantIndex + n);
+            else
+                dire_queue.push(direIndex + n);
+        }
+
+        return radiant_queue.empty() ? "Dire" : "Radiant";
+    }
+};

--- a/Gombang/[LeetCode75] - [Queue]/933_Number_of_Recent_Calls.cpp
+++ b/Gombang/[LeetCode75] - [Queue]/933_Number_of_Recent_Calls.cpp
@@ -1,0 +1,54 @@
+// 두 번째 풀이
+class RecentCounter {
+public:
+
+    RecentCounter() {
+
+    }
+
+    int ping(int t) {
+        queue.push(t);
+
+        while (queue.size() > 0 && queue.front() < t - 3000)
+        {
+            queue.pop();
+        }
+
+        return queue.size();
+    }
+
+private:
+
+    queue<int> queue;
+};
+
+
+// 첫 번째 풀이
+// 582 ms
+class RecentCounter {
+public:
+
+    RecentCounter() {
+
+    }
+
+    int ping(int t) {
+        requests.push_back(t);
+
+        int min = t - 3000;
+        int max = t;
+        int count = 0;
+
+        for (int i = 0; i < requests.size(); i++)
+        {
+            if (requests[i] >= min && requests[i] <= max)
+                count++;
+        }
+
+        return count;
+    }
+
+private:
+
+    vector<int> requests;
+};


### PR DESCRIPTION
# 25년 6주차 TIL

## 1. Number of Recent Calls(LeetCode 933)

- 첫 번째 풀이 방법은 단순하게 벡터에다가 주어지는 입력값을 추가하고, 벡터를 모두 순회하면서 주어진 조건에 맞는 것을 카운팅 하는 방식으로 진행했지만, 582ms라는 시간이 걸리게 되었다. 더 좋은 방법에 대해서 알아보기 위해 솔루션을 참고하였습니다.
 
- 솔루션의 방식은 입력값을 큐에다가 추가하고 큐의 맨 앞에 해당하는 값이 t - 3000보다 작은 경우에만 pop을 하는 방식으로 진행하여 훨씬 빠른 시간에 처리할 수 있었습니다. 

## 2. Dota2 Senate(LeetCode 649)

- 해당 문제는 문제를 읽어보았을 때 무엇을 물어보는지를 잘 파악하지 못하여, 팀원의 풀이방식을 참고하여 문제를 풀게 되었습니다. radiant와 dire에 대한 두 개의 큐를 만들어서 인덱스를 저장하는 방식으로 처리하였습니다. 

## 3. 택배 배달과 수거하기(Programmers 카카오 2023)

- 문제를 어떻게 풀까에 대해서 처리해보니 최소 거리를 움직이기 위해서는 가장 먼 지점부터 배달 혹은 수거를 해야 한다는 것을 알게되었습니다. 또한, 가장 먼 지점에 방문을 하기 위해 왔다갔다 할 경우 물류 창고 ~ 가장 먼 집 사이의 거리의 두 배 만큼 이동해야 한다는 것을 파악하여 문제 풀이를 진행하였스빈다.

- deliveries의 맨 뒤를 가리키는 인덱스 변수와 pickups의 맨 뒤를 가리키는 인덱스 변수 이렇게 두 개의 변수를 통해서 접근을 하였고, 누적된 값을 cap과 비교하여 cap이하일때까지는 배달이든 수거든 모든 것을 완료한다는 개념으로 풀이를 진행하였습니다.