### PR TITLE
[프로그래머스+LeetCode 75] [Gombang] 25년 7주차 3문제 풀이

### DIFF
--- a/Gombang/Programmers/이모티콘 할인행사.cpp
+++ b/Gombang/Programmers/이모티콘 할인행사.cpp
@@ -1,0 +1,74 @@
+#include <string>
+#include <vector>
+
+using namespace std;
+
+int discountRates[] = { 10, 20, 30, 40 };
+
+// 백 트래킹 방식으로 조합 구성.
+void generateCombination(vector<vector<int>>& discountLists, vector<int>& currCombination,
+    int depth, int emoticonSize)
+{
+    if (depth == emoticonSize)
+    {
+        discountLists.push_back(currCombination);
+        return;
+    }
+
+    for (int i = 0; i < 4; i++)
+    {
+        currCombination.push_back(discountRates[i]);
+        generateCombination(discountLists, currCombination, depth + 1, emoticonSize);
+        currCombination.pop_back();
+    }
+}
+
+vector<int> solution(vector<vector<int>> users, vector<int> emoticons) {
+
+    // 정답 제출용 변수 설정.
+    int answerEmoticonPlusCount = 0;
+    int answerPrice = 0;
+
+    // 각 이모티콘에 대한 할인율 조합 변수 설정.
+    vector<vector<int>> discountLists;
+    vector<int> currCombination;
+
+    // discountLists의 조합을 구하는 과정 진행.
+    generateCombination(discountLists, currCombination, 0, emoticons.size());
+
+    for (int i = 0; i < discountLists.size(); i++)
+    {
+        int newEmoticonPlusCount = 0;
+        int newTotalPrice = 0;
+
+        // 모든 유저들에 대해서 적용된 할인율에 대해서 구매하거나 이모티콘 플러스를 가입하는 과정.
+        for (int userIndex = 0; userIndex < users.size(); userIndex++)
+        {
+            // users[userIndex][0] : 할인율 역치
+            // users[userIndex][1] : 구매 비용 역치
+            int sum = 0;
+
+            for (int j = 0; j < emoticons.size(); j++)
+            {
+                if (users[userIndex][0] <= discountLists[i][j])
+                    sum += (emoticons[j] * (100 - discountLists[i][j])) / 100;
+            }
+
+            if (sum >= users[userIndex][1])
+                newEmoticonPlusCount++;
+            else
+                newTotalPrice += sum;
+        }
+
+        // 새로운 할인율을 적용했을 때, 더 많은 플러스 가입자가 있거나, 가입자 수는 같지만 판매 비용이 높으면
+        if (answerEmoticonPlusCount < newEmoticonPlusCount ||
+            (answerEmoticonPlusCount == newEmoticonPlusCount && answerPrice < newTotalPrice))
+        {
+            answerEmoticonPlusCount = newEmoticonPlusCount;
+            answerPrice = newTotalPrice;
+        }
+    }
+
+
+    return { answerEmoticonPlusCount, answerPrice };
+}

--- a/Gombang/[LeetCode75] - [Linked List]/2095_Delete_the_Middle_Node_of_a_Linked_List.cpp
+++ b/Gombang/[LeetCode75] - [Linked List]/2095_Delete_the_Middle_Node_of_a_Linked_List.cpp
@@ -1,0 +1,49 @@
+// 모범 답안 풀이.
+class Solution {
+public:
+    ListNode* deleteMiddle(ListNode* head) {
+        if (head->next == nullptr) {
+            return nullptr;
+        }
+        ListNode* slow = head;
+        ListNode* fast = head->next;
+        while (fast->next != nullptr && fast->next->next != nullptr) {
+            fast = fast->next->next;
+            slow = slow->next;
+        }
+        slow->next = slow->next->next;
+        return head;
+    }
+};
+
+// 첫 번째 풀이.
+class Solution {
+public:
+    ListNode* deleteMiddle(ListNode* head) {
+
+        // 사이즈가 1일때,
+        if (head->next == nullptr)
+            return nullptr;
+
+        // 1. 전체 사이즈 구하기.
+        int size = 0;
+        ListNode* temp = head;
+        while (temp != nullptr)
+        {
+            size++;
+            temp = temp->next;
+        }
+
+        // 2. 중간 노드의 전 노드를 구하는 과정.
+        temp = head;
+        for (int i = 0; i < size / 2 - 1; i++)
+        {
+            temp = temp->next;
+        }
+
+        // 중간 노드를 건너뛰도록 연결.
+        temp->next = temp->next->next;
+
+        return head;
+    }
+};

--- a/Gombang/[LeetCode75] - [Linked List]/328_Odd_Even_Linked_List.cpp
+++ b/Gombang/[LeetCode75] - [Linked List]/328_Odd_Even_Linked_List.cpp
@@ -1,0 +1,36 @@
+/**
+ * Definition for singly-linked list.
+ * struct ListNode {
+ *     int val;
+ *     ListNode *next;
+ *     ListNode() : val(0), next(nullptr) {}
+ *     ListNode(int x) : val(x), next(nullptr) {}
+ *     ListNode(int x, ListNode *next) : val(x), next(next) {}
+ * };
+ */
+class Solution {
+public:
+    ListNode* oddEvenList(ListNode* head) {
+
+        if (head == nullptr || head->next == nullptr)
+            return head;
+
+        ListNode* oddNode = head;
+        ListNode* evenNode = head->next;
+        ListNode* evenHeadNode = evenNode;
+
+        // 반복문의 조건을 evenNode를 기준으로 한 이유는 그룹화하는 과정에 있어서
+        // 홀수번째와 짝수번째가 서로 쌍을 가지며 정리가 되어야 하기 때문에.
+        while (evenNode != nullptr && evenNode->next != nullptr)
+        {
+            oddNode->next = evenNode->next;
+            oddNode = oddNode->next;
+
+            evenNode->next = oddNode->next;
+            evenNode = evenNode->next;
+        }
+
+        oddNode->next = evenHeadNode;
+        return head;
+    }
+};


### PR DESCRIPTION
# 25년 7주차 TIL

## LeetCode75 [2095. Delete the Middle Node of a Linked List]

- 중간 노드를 제거하기 위해서, 중간 노드의 전 노드를 알아야 한다. 전체를 순회하여 사이즈를 구하고, `사이즈의 절반 - 1` 만큼만 이동하면 전 노드를 알 수 있다.

- 그런데 위의 방법은 두 번 순회를 하는 개념이기에, 한 번만 순회를 하면서 중간 노드를 제거하는 방법은 없을까하여 다른 솔루션을 확인해보았다. slow와 fast라는 두 변수를 통해, fast는 두 칸 다음으로 이동할 때 slow는 한 칸만 다음으로 이동한다면, 모든 while문을 다 돌았을 때 slow는 중간 노드의 전 단계를 가리키도록 구할 수 있었다.

## LeetCode75 [328. Odd Even Linked List]

- odd와 even에 대해서 리스트를 그룹화하고, 마지막에 odd와 even을 연결해주는 방식으로 진행하였다.

- 마지막에 연결할 때, even의 head를 알고있어야 odd와 연결할 수 있으므로 시작 전, evenHeadNode라는 변수를 통해 미리 저장하도록 변수를 추가하였다.

## Programmers [이모티콘 할인행사]

- 해당 문제는 완전 탐색을 통해, 모든 경우의 수에 대한 할인율을 이모티콘 정가에 적용하여 사용자의 역치 값과 비교하여 가입자 수와 판매액이 최대가 되는 값을 구하도록 처리하였습니다.

- 정답 제출용 판매액, 전체 판매액, 누적 판매액 등 변수명을 짓기가 까다로웠던 문제였다.