### PR TITLE
[프로그래머스+LeetCode 75] [Gombang] 25년 9주차 3문제 풀이

### DIFF
--- a/Gombang/Programmers/표 병합.cpp
+++ b/Gombang/Programmers/표 병합.cpp
@@ -1,0 +1,233 @@
+#include <string>
+#include <vector>
+#include <sstream>
+#include <unordered_map>
+#include <iostream>
+
+using namespace std;
+
+const int ROWS = 51;
+const int COLS = 51;
+
+class Cell
+{
+public:
+    Cell(int _y, int _x) : y(_y), x(_x), content("EMPTY") {}
+
+    void UpdateContent(const string& newContent)
+    {
+        content = newContent;
+
+        // 머지가 되어 있다면 머지된 Cell들에도 내용을 변경해준다.
+        for (const auto& mergedCell : mergedCellMap)
+        {
+            (mergedCell.first)->onNotified(newContent);
+        }
+    }
+
+    void MergeCell(Cell* cell)
+    {
+        // cell이 본인이거나, 기존에 저장되어 있는 cell이라면 return.
+        if (cell == this ||
+            mergedCellMap.find(cell) != mergedCellMap.end())
+            return;
+
+        mergedCellMap[cell]++;
+        cell->MergeCell(this);
+
+        for (auto& mergedCell : mergedCellMap)
+        {
+            (mergedCell.first)->MergeCell(cell);
+            cell->MergeCell(mergedCell.first);
+        }
+    }
+
+    // 병합 해제
+    void UnMerge()
+    {
+        string tmpStr = this->content;
+
+        // 머지되었던 셀들을 순회하면서 머지된 셀들의 mergedCellMap에 대해서 clear진행.
+        for (auto& mergedCell : mergedCellMap)
+        {
+            (mergedCell.first)->ClearMergedCell();
+        }
+
+        // 본인의 mergedCellMap초기화.
+        ClearMergedCell();
+        UpdateContent(tmpStr);
+    }
+
+    string GetContent() const
+    {
+        return content;
+    }
+
+private:
+    void onNotified(const string& newContent)
+    {
+        content = newContent;
+    }
+
+    void ClearMergedCell()
+    {
+        this->content = "EMPTY";
+        mergedCellMap.clear();
+    }
+
+private:
+    int y, x;
+    string content;
+
+    unordered_map<Cell*, int> mergedCellMap;
+};
+
+enum class CommandType
+{
+    UPDATE,
+    MERGE,
+    UNMERGE,
+    PRINT
+};
+
+CommandType GetCommandType(string str)
+{
+    if (str == "UPDATE")
+        return CommandType::UPDATE;
+    else if (str == "MERGE")
+        return CommandType::MERGE;
+    else if (str == "UNMERGE")
+        return CommandType::UNMERGE;
+    else
+        return CommandType::PRINT;
+}
+
+vector<string> answer;
+
+void ExecuteCommand(CommandType commandType, vector<string>& args, vector<vector<Cell>>& table)
+{
+    switch (commandType)
+    {
+    case CommandType::UPDATE:
+    {
+        if (args.size() == 3)
+        {
+            // (args[0], args[1]) 위치의 내용을 args[2]로 바꾸기.
+            int y = stoi(args[0]);
+            int x = stoi(args[1]);
+
+            table[y][x].UpdateContent(args[2]);
+        }
+        else if (args.size() == 2)
+        {
+            string currString = args[0];
+            string nextString = args[1];
+
+            // args[0]을 가지고 있는 모든 셀을 선택해서 args[1]로 바꾸기.
+            for (int i = 0; i < ROWS; i++)
+            {
+                for (int j = 0; j < COLS; j++)
+                {
+                    if (table[i][j].GetContent() == currString)
+                    {
+                        table[i][j].UpdateContent(nextString);
+                    }
+                }
+            }
+        }
+        else
+        {
+            // error
+        }
+    }
+    break;
+
+    case CommandType::MERGE:
+    {
+        // (args[0], args[1]) 위치의 셀과 (args[2], args[3]) 위치의 셀을 선택하여 병합.
+        int y1 = stoi(args[0]);
+        int x1 = stoi(args[1]);
+
+        int y2 = stoi(args[2]);
+        int x2 = stoi(args[3]);
+
+        table[y1][x1].MergeCell(&table[y2][x2]);
+
+        if (table[y1][x1].GetContent() != "EMPTY")
+            table[y1][x1].UpdateContent(table[y1][x1].GetContent());
+        else
+        {
+            if (table[y2][x2].GetContent() != "EMPTY")
+            {
+                table[y1][x1].UpdateContent(table[y2][x2].GetContent());
+            }
+        }
+    }
+    break;
+
+    case CommandType::UNMERGE:
+    {
+        // (args[0], args[1])에 연결되어 있는 셀들의 병합을 해제한다.
+        // 해제 시에 값을 가지고 있는 경우 (args[0], args[1]) 이 위치가 가져간다.
+
+        int y = stoi(args[0]);
+        int x = stoi(args[1]);
+
+        table[y][x].UnMerge();
+    }
+    break;
+
+    case CommandType::PRINT:
+    {
+        int y = stoi(args[0]);
+        int x = stoi(args[1]);
+
+        answer.push_back(table[y][x].GetContent());
+        // (args[0], args[1]) 위치의 셀을 출력한다.
+
+    }
+    break;
+
+    default:
+        break;
+    }
+}
+
+vector<string> solution(vector<string> commands) {
+    
+    // table초기화.
+    vector<vector<Cell>> table;
+    table.reserve(ROWS);
+    for (int i = 0; i < ROWS; i++)
+    {
+        vector<Cell> row;
+        row.reserve(COLS);
+        for (int j = 0; j < COLS; j++)
+        {
+            row.push_back(Cell(i, j));
+        }
+
+        table.push_back(move(row));
+    }
+
+    for (string& command : commands)
+    {
+        // 빈칸을 기준으로 commandDatas에 데이터 추가.
+        istringstream input(command);
+        string tempString;
+        vector<string> commandDatas;
+        while (input >> tempString)
+        {
+            commandDatas.push_back(tempString);
+        }
+
+        // 0번째는 커맨드 타입에 대한 데이터이므로, args에 +1부터 end까지 깊은 복사 수행.
+        vector<string> argVec(commandDatas.begin() + 1, commandDatas.end());
+        CommandType commandType = GetCommandType(commandDatas[0]);
+
+        // 커맨드 실행.
+        ExecuteCommand(commandType, argVec, table);
+    }
+
+    return answer;
+}

--- a/Gombang/[LeetCode75] - [DFS]/104_Maximum_Depth_of_Binary_Tree.cpp
+++ b/Gombang/[LeetCode75] - [DFS]/104_Maximum_Depth_of_Binary_Tree.cpp
@@ -1,0 +1,32 @@
+/**
+ * Definition for a binary tree node.
+ * struct TreeNode {
+ *     int val;
+ *     TreeNode *left;
+ *     TreeNode *right;
+ *     TreeNode() : val(0), left(nullptr), right(nullptr) {}
+ *     TreeNode(int x) : val(x), left(nullptr), right(nullptr) {}
+ *     TreeNode(int x, TreeNode *left, TreeNode *right) : val(x), left(left), right(right) {}
+ * };
+ */
+class Solution {
+public:
+
+    int _maxDepth = 0;
+
+    int maxDepth(TreeNode* root) {
+        DFS(root, 1);
+
+        return _maxDepth;
+    }
+
+    void DFS(TreeNode* node, int depth)
+    {
+        if (node == nullptr)
+            return;
+
+        _maxDepth = max(_maxDepth, depth);
+        DFS(node->left, depth + 1);
+        DFS(node->right, depth + 1);
+    }
+};

--- a/Gombang/[LeetCode75] - [DFS]/872_Leaf-Similar_Trees.cpp
+++ b/Gombang/[LeetCode75] - [DFS]/872_Leaf-Similar_Trees.cpp
@@ -1,0 +1,47 @@
+/**
+ * Definition for a binary tree node.
+ * struct TreeNode {
+ *     int val;
+ *     TreeNode *left;
+ *     TreeNode *right;
+ *     TreeNode() : val(0), left(nullptr), right(nullptr) {}
+ *     TreeNode(int x) : val(x), left(nullptr), right(nullptr) {}
+ *     TreeNode(int x, TreeNode *left, TreeNode *right) : val(x), left(left), right(right) {}
+ * };
+ */
+class Solution {
+public:
+    bool leafSimilar(TreeNode* root1, TreeNode* root2) {
+        vector<int> root1Vec;
+        vector<int> root2Vec;
+
+        DFS(root1, root1Vec);
+        DFS(root2, root2Vec);
+
+        if (root1Vec.size() != root2Vec.size())
+            return false;
+
+        for (int i = 0; i < root1Vec.size(); i++)
+        {
+            if (root1Vec[i] != root2Vec[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    void DFS(TreeNode* node, vector<int>& vec)
+    {
+        if (node == nullptr)
+            return;
+
+        if (node->left == nullptr && node->right == nullptr)
+        {
+            vec.push_back(node->val);
+            return;
+        }
+
+        DFS(node->left, vec);
+        DFS(node->right, vec);
+    }
+};


### PR DESCRIPTION
# 25년 9주차 TIL

## 1. Maximum Depth of Binary Tree [ LeetCode 104 ]
- dfs를 이용하여 문제를 해결하였다.
- easy문제여서 크게 어려운점은 없었다.
- 서리님의 발표를 통해 전위순회, 중위순회, 후위순회에 대해서 다시 한 번 알아보는 시간을 가져보았다.

## 2. Leaf-Similar Trees [ LeetCode 872 ]
- 벡터를 만들어서 각 루트로부터 dfs로 순회하여 리프노드에 대해 값을 각 벡터에 넣어주고 비교하는 방식으로 진행하였다.
- 순회 방식은 1번과 동일하게 진행하였다.

## 3. 표 병합(Programmers 카카오 2023)

- 통과를 하진 못했다. 21번 테스트 케이스가 시간 초과가 나서 95.5점으로 마무리 되었다.

- 해당 문제에 대해서 클래스로 구현하여 문제를 풀면 재미있을 것 같아 Cell이라는 클래스를 하나 만들어서 진행하였다.

- Merge와 UnMerge에 대해서 어떻게 처리해야 할 지 고민이 많았는데, Cell클래스에 Map자료구조인 변수를 하나 두고 이 Map자료구조의 Key값을 `Merge를 할 다른 Cell의 주소값`으로 설정해주었다. Merge를 진행할 때 해당 Map변수에 추가하는 과정으로 진행하였는데 추가하려는 Cell이 이미 다른 Cell과 Merge를 했을 수도 있으므로, 재귀호출을 통해 추가하려는 Cell의 Map을 또 돌려주면서 추가해주는 과정을 진행하였다.

  --> 예를 들어, A셀, B셀, C셀이 있다고 해보자. 이미 기존에 **B셀과 C셀이 머지되어 있다**고 했을 때 **B셀의 Map에는 C가 등록**되어 있을 것이고, **C셀의 Map에는 B셀이 등록**되어 있을 것이다. 이때, A셀에서 B셀과 머지를 할 경우 **A셀의 Map에는 B셀을 등록** 시켜줄 것인데 **B셀 또한 A셀을 등록**시켜줘야 한다. 또한, **B셀의 Map에 등록되어 있던 C셀도 A셀과 머지를 진행해주어야 하므로, B셀의 Map에 대해서 전체 순회를 하며 A셀과 머지를 하는 과정을 진행**해준다.

- 위의 Merge과정에 대해서 이미 다른 셀과 Merge가 많이 되어 있을 때, 너무 많은 연산을 진행해야 하므로 21번 테스트 케이스에서 시간 초과가 난 것 같다.

- 서리님의 발표를 통해 union-find알고리즘에 대해서 알게 되었고, 부모를 찾아가는 과정에 대한 알고리즘인데 이 문제에 아주 적절하게 쓰이는 방식인 것 같아 이 방식으로 다시 풀어봐야겠다.