### PR TITLE
[프로그래머스+LeetCode 75] [Seori] 25년 10주차 3문제 풀이

### DIFF
--- a/Seori/LeetCode 75/Binary Tree_DFS/1448. Count Good Nodes in Binary Tree.py
+++ b/Seori/LeetCode 75/Binary Tree_DFS/1448. Count Good Nodes in Binary Tree.py
@@ -1,0 +1,27 @@
+# Definition for a binary tree node.
+# class TreeNode:
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution:
+    def goodNodes(self, root: TreeNode) -> int:
+        
+        def dfs(root: TreeNode, value: int) -> int:
+            # 재귀 종료조건
+            if root == None:
+                return 0
+
+            # 최대값 value를 체크하면서 count를 갱신하고
+            count = 0
+            if root.val >= value:
+                value = root.val
+                count += 1
+            
+            # 이진트리 전위순회
+            count += dfs(root.left, value)
+            count += dfs(root.right, value)
+        
+            return count
+            
+        return dfs(root, root.val)

--- a/Seori/LeetCode 75/Binary Tree_DFS/437. Path Sum III.py
+++ b/Seori/LeetCode 75/Binary Tree_DFS/437. Path Sum III.py
@@ -1,0 +1,30 @@
+# Definition for a binary tree node.
+# class TreeNode:
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution:
+    def pathSum(self, root: Optional[TreeNode], targetSum: int) -> int:
+        def dfs(root: Optional[TreeNode], level: int, listSum: List) -> int:
+            # 재귀 종료조건
+            if root == None:
+                return 0
+            
+            # 매 노드를 탐색하는 시점에 구간 누적합을 체크
+            count = 0
+            value = root.val
+            new_listSum = listSum[:]
+            new_listSum.append(0)
+            for i in range(level):
+                new_listSum[i] += value
+                if new_listSum[i] == targetSum:
+                    count += 1
+            
+            # 전위순회
+            count += dfs(root.left, level + 1, new_listSum)
+            count += dfs(root.right, level + 1, new_listSum)
+
+            return count
+
+        return dfs(root, 1, [])

--- a/Seori/Programmers/미로 탈출 명령어.py
+++ b/Seori/Programmers/미로 탈출 명령어.py
@@ -1,0 +1,52 @@
+def solution(n, m, x, y, r, c, k):
+    # [1] k가 거리보다 작거나, 홀짝이 다른 경우는 불가능
+    distance = abs(c - y) + abs(r - x)
+    if k < distance or (distance % 2 != k % 2):
+        return "impossible"
+    
+    # [2] 시작점에서 도착점까지의 경로를 구함
+    path = ''
+    y_move = r - x
+    if y_move > 0:
+        path += 'd' * y_move
+        y_max = r
+    else: 
+        path += 'u' * (-y_move)
+        y_max = x
+    
+    x_move = c - y
+    if x_move > 0:
+        path += 'r' * x_move
+        x_min = y
+    else: 
+        path += 'l' * (-x_move)
+        x_min = c
+    
+    # [3] 시작점과 도착점 중 영점(가장 왼쪽 밑)에 가까운 곳에서 영점까지의 경로를 구함.
+    #     사전순 d, l, r, u 순에서 유리한게 왼쪽 밑이기 때문
+    k -= distance
+    while k:
+        if y_max < n: 
+            path += 'du'
+            y_max += 1
+            k -= 2
+            continue
+        
+        if x_min > 1:
+            path += 'lr'
+            x_min -= 1
+            k -= 2
+            continue
+        break
+    
+    # [4] 지금까지 경로를 사전순으로 정렬하고, 남은 이동 횟수에 따라서 loop(rl 반복)를 추가함
+    answer = ''.join(sorted(path))
+    loop = 'rl' * (k // 2)
+
+    r_index = answer.find('r')
+    if r_index == -1:
+        u_index = answer.find('u')
+        if u_index == -1:
+            return answer + loop
+        return answer[:u_index] + loop + answer[u_index:]
+    return answer[:r_index] + loop + answer[r_index:]

--- a/Seori/TIL/25년 10주차 TIL.md
+++ b/Seori/TIL/25년 10주차 TIL.md
@@ -1,0 +1,152 @@
+# 25년 10주차 TIL
+
+## 1. Count Good Nodes in Binary Tree(LeetCode 1448)
+
+10주차도 연속해서 발표를 맡게 됐다. 지난 주와 같은 유형의 트리 `DFS`였고, 이진트리의 완전탐색이다 보니 풀이의 틀도 크게 다르지는 않았다.
+
+### 풀이
+
+```python
+# Definition for a binary tree node.
+# class TreeNode:
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution:
+    def goodNodes(self, root: TreeNode) -> int:
+        
+        def dfs(root: TreeNode, value: int) -> int:
+            # 재귀 종료조건
+            if root == None:
+                return 0
+
+            # 최대값 value를 체크하면서 count를 갱신하고
+            count = 0
+            if root.val >= value:
+                value = root.val
+                count += 1
+            
+            # 이진트리 전위순회
+            count += dfs(root.left, value)
+            count += dfs(root.right, value)
+        
+            return count
+            
+        return dfs(root, root.val)
+```
+
+## 2. Path Sum III**(LeetCode** 437**)**
+
+이 문제는 노드에 도달했을 시점의 누적합을 구해야했는데, 노드 깊이에 따라 누적합 리스트의 길이가 달라져야 했다. 그래서 처음에는 빈 리스트`[]`를 넣어주고 재귀하면서 `append`에 따라 길이가 길어지는 누적합 리스트를 만들어 해결했다.
+
+### 풀이
+
+```python
+# Definition for a binary tree node.
+# class TreeNode:
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution:
+    def pathSum(self, root: Optional[TreeNode], targetSum: int) -> int:
+        def dfs(root: Optional[TreeNode], level: int, listSum: List) -> int:
+            # 재귀 종료조건
+            if root == None:
+                return 0
+            
+            # 매 노드를 탐색하는 시점에 구간 누적합을 체크
+            count = 0
+            value = root.val
+            new_listSum = listSum[:]
+            new_listSum.append(0)
+            for i in range(level):
+                new_listSum[i] += value
+                if new_listSum[i] == targetSum:
+                    count += 1
+            
+            # 전위순회
+            count += dfs(root.left, level + 1, new_listSum)
+            count += dfs(root.right, level + 1, new_listSum)
+
+            return count
+
+        return dfs(root, 1, [])
+```
+
+## 3. 미로 탈출(Programmers 카카오 2023)
+
+미로에서 경로를 탐색하는 문제였다.
+
+1. 같은 곳에 반복해서 방문할 수 있다.
+2. 장애물이 없다.
+3. 사전순으로 정렬해서 정답을 반환해야 한다.
+
+위 3가지 조건이 걸려 있어 평범한 완전탐색으로는 풀기 버거울 거라고 판단하고 `Greedy`하게 풀이했다. (나중에 찾아보니 간단한 `DFS`풀이도 있었다.)
+
+[2] 시작점부터 도착점까지의 경로와
+
+[3] 영점까지의 경로를 먼저 구해서 정렬해두고
+
+[4] 영점에 도착한 시점부터는 가장 유리한 이동이 rl이기 때문에
+
+남은 `k`만큼 rl을 제 위치에 붙여서 정답을 낼 수 있었다.
+
+### 풀이
+
+```python
+def solution(n, m, x, y, r, c, k):
+    # [1] k가 거리보다 작거나, 홀짝이 다른 경우는 불가능
+    distance = abs(c - y) + abs(r - x)
+    if k < distance or (distance % 2 != k % 2):
+        return "impossible"
+    
+    # [2] 시작점에서 도착점까지의 경로를 구함
+    path = ''
+    y_move = r - x
+    if y_move > 0:
+        path += 'd' * y_move
+        y_max = r
+    else: 
+        path += 'u' * (-y_move)
+        y_max = x
+    
+    x_move = c - y
+    if x_move > 0:
+        path += 'r' * x_move
+        x_min = y
+    else: 
+        path += 'l' * (-x_move)
+        x_min = c
+    
+    # [3] 시작점과 도착점 중 영점(가장 왼쪽 밑)에 가까운 곳에서 영점까지의 경로를 구함.
+    #     사전순 d, l, r, u 순에서 유리한게 왼쪽 밑이기 때문
+    k -= distance
+    while k:
+        if y_max < n: 
+            path += 'du'
+            y_max += 1
+            k -= 2
+            continue
+        
+        if x_min > 1:
+            path += 'lr'
+            x_min -= 1
+            k -= 2
+            continue
+        break
+    
+    # [4] 지금까지 경로를 사전순으로 정렬하고, 남은 이동 횟수에 따라서 loop(rl 반복)를 추가함
+    answer = ''.join(sorted(path))
+    loop = 'rl' * (k // 2)
+
+    r_index = answer.find('r')
+    if r_index == -1:
+        u_index = answer.find('u')
+        if u_index == -1:
+            return answer + loop
+        return answer[:u_index] + loop + answer[u_index:]
+    return answer[:r_index] + loop + answer[r_index:]
+
+```


### PR DESCRIPTION
# 25년 10주차 TIL

## 1. Count Good Nodes in Binary Tree(LeetCode 1448)

10주차도 연속해서 발표를 맡게 됐다. 지난 주와 같은 유형의 트리 `DFS`였고, 이진트리의 완전탐색이다 보니 풀이의 틀도 크게 다르지는 않았다.

### 풀이

```python
# Definition for a binary tree node.
# class TreeNode:
#     def __init__(self, val=0, left=None, right=None):
#         self.val = val
#         self.left = left
#         self.right = right
class Solution:
    def goodNodes(self, root: TreeNode) -> int:
        
        def dfs(root: TreeNode, value: int) -> int:
            # 재귀 종료조건
            if root == None:
                return 0

            # 최대값 value를 체크하면서 count를 갱신하고
            count = 0
            if root.val >= value:
                value = root.val
                count += 1
            
            # 이진트리 전위순회
            count += dfs(root.left, value)
            count += dfs(root.right, value)
        
            return count
            
        return dfs(root, root.val)
```

## 2. Path Sum III**(LeetCode** 437**)**

이 문제는 노드에 도달했을 시점의 누적합을 구해야했는데, 노드 깊이에 따라 누적합 리스트의 길이가 달라져야 했다. 그래서 처음에는 빈 리스트`[]`를 넣어주고 재귀하면서 `append`에 따라 길이가 길어지는 누적합 리스트를 만들어 해결했다.

### 풀이

```python
# Definition for a binary tree node.
# class TreeNode:
#     def __init__(self, val=0, left=None, right=None):
#         self.val = val
#         self.left = left
#         self.right = right
class Solution:
    def pathSum(self, root: Optional[TreeNode], targetSum: int) -> int:
        def dfs(root: Optional[TreeNode], level: int, listSum: List) -> int:
            # 재귀 종료조건
            if root == None:
                return 0
            
            # 매 노드를 탐색하는 시점에 구간 누적합을 체크
            count = 0
            value = root.val
            new_listSum = listSum[:]
            new_listSum.append(0)
            for i in range(level):
                new_listSum[i] += value
                if new_listSum[i] == targetSum:
                    count += 1
            
            # 전위순회
            count += dfs(root.left, level + 1, new_listSum)
            count += dfs(root.right, level + 1, new_listSum)

            return count

        return dfs(root, 1, [])
```

## 3. 미로 탈출(Programmers 카카오 2023)

미로에서 경로를 탐색하는 문제였다.

1. 같은 곳에 반복해서 방문할 수 있다.
2. 장애물이 없다.
3. 사전순으로 정렬해서 정답을 반환해야 한다.

위 3가지 조건이 걸려 있어 평범한 완전탐색으로는 풀기 버거울 거라고 판단하고 `Greedy`하게 풀이했다. (나중에 찾아보니 간단한 `DFS`풀이도 있었다.)

[2] 시작점부터 도착점까지의 경로와

[3] 영점까지의 경로를 먼저 구해서 정렬해두고

[4] 영점에 도착한 시점부터는 가장 유리한 이동이 rl이기 때문에

남은 `k`만큼 rl을 제 위치에 붙여서 정답을 낼 수 있었다.

### 풀이

```python
def solution(n, m, x, y, r, c, k):
    # [1] k가 거리보다 작거나, 홀짝이 다른 경우는 불가능
    distance = abs(c - y) + abs(r - x)
    if k < distance or (distance % 2 != k % 2):
        return "impossible"
    
    # [2] 시작점에서 도착점까지의 경로를 구함
    path = ''
    y_move = r - x
    if y_move > 0:
        path += 'd' * y_move
        y_max = r
    else: 
        path += 'u' * (-y_move)
        y_max = x
    
    x_move = c - y
    if x_move > 0:
        path += 'r' * x_move
        x_min = y
    else: 
        path += 'l' * (-x_move)
        x_min = c
    
    # [3] 시작점과 도착점 중 영점(가장 왼쪽 밑)에 가까운 곳에서 영점까지의 경로를 구함.
    #     사전순 d, l, r, u 순에서 유리한게 왼쪽 밑이기 때문
    k -= distance
    while k:
        if y_max < n: 
            path += 'du'
            y_max += 1
            k -= 2
            continue
        
        if x_min > 1:
            path += 'lr'
            x_min -= 1
            k -= 2
            continue
        break
    
    # [4] 지금까지 경로를 사전순으로 정렬하고, 남은 이동 횟수에 따라서 loop(rl 반복)를 추가함
    answer = ''.join(sorted(path))
    loop = 'rl' * (k // 2)

    r_index = answer.find('r')
    if r_index == -1:
        u_index = answer.find('u')
        if u_index == -1:
            return answer + loop
        return answer[:u_index] + loop + answer[u_index:]
    return answer[:r_index] + loop + answer[r_index:]

```