### PR TITLE
[프로그래머스+LeetCode 75] [Gombang] 25년 11주차 3문제 풀이

### DIFF
--- a/Gombang/Programmers/행렬과 연산.cpp
+++ b/Gombang/Programmers/행렬과 연산.cpp
@@ -1,0 +1,272 @@
+///////////////////////////////////////
+///////// 해설을 참고하여 풀이 //////////
+///////////////////////////////////////
+
+#include <string>
+#include <vector>
+#include <deque>
+
+using namespace std;
+
+vector<vector<int>> solution(vector<vector<int>> rc, vector<string> operations) {
+
+    int row = rc.size();
+    int col = rc[0].size();
+
+    deque<int> left;
+    deque<int> right;
+    deque<deque<int>> middle;
+
+    for (int i = 0; i < row; i++)
+    {
+        left.push_back(rc[i][0]);
+        right.push_back(rc[i][col - 1]);
+
+        deque<int> tempRow;
+        for (int j = 1; j < col - 1; j++)
+        {
+            tempRow.push_back(rc[i][j]);
+        }
+        middle.push_back(tempRow);
+    }
+
+    for (string operation : operations)
+    {
+        if (operation == "ShiftRow")
+        {
+            left.push_front(left.back());
+            left.pop_back();
+
+            middle.push_front(move(middle.back()));
+            middle.pop_back();
+
+            right.push_front(right.back());
+            right.pop_back();
+        }
+        else
+        {
+            deque<int>& firstRow = middle.front();
+            deque<int>& lastRow = middle.back();
+
+            firstRow.push_front(left.front());
+            left.pop_front();
+
+            right.push_front(firstRow.back());
+            firstRow.pop_back();
+
+            lastRow.push_back(right.back());
+            right.pop_back();
+
+            left.push_back(lastRow.front());
+            lastRow.pop_front();
+        }
+    }
+
+    vector<vector<int>> answer(row);
+
+    for (int i = 0; i < row; i++)
+    {
+        answer[i].push_back(left[i]);
+
+        for (int j = 0; j < middle[i].size(); j++)
+        {
+            answer[i].push_back(middle[i][j]);
+        }
+
+        answer[i].push_back(right[i]);
+    }
+
+    return answer;
+}
+
+
+
+///////////////////////////////////////
+///////// 두 번째 풀이 실패 ////////////
+///////////////////////////////////////
+#include <string>
+#include <vector>
+
+using namespace std;
+
+const string SHIFT_ROW = "ShiftRow";
+const string ROTATE = "Rotate";
+
+// 인덱스에 대한 좌표 구하기.
+pair<int, int> getCoordinates(int i, int row, int col)
+{
+    int topCount = col;
+    int rightCount = row - 1;
+    int bottomCount = col - 1;
+    int leftCount = row - 2;
+
+    if (i < topCount)
+        return { 0, i };
+
+    i -= topCount;
+    if (i < rightCount)
+        return { i + 1, col - 1 };
+
+    i -= rightCount;
+    if (i < bottomCount)
+        return { row - 1, col - i - 2 };
+
+    i -= bottomCount;
+    if (i < leftCount)
+        return { row - 2 - i, 0 };
+
+    return { -1, -1 };
+}
+
+void ExecuteRotateCommand(int commandCount, vector<vector<int>>& rc)
+{
+    int row = rc.size();
+    int col = rc[0].size();
+    int totalLoopCount = col * row - ((row - 2) * (col - 2));
+    // 본 코드 실패 후 이 코드를 추가하였지만 동일한 점수가 나옴.
+    if (commandCount == totalLoopCount)
+        return;
+
+    vector<vector<int>> prevArray = rc;
+
+    for (int i = 0; i < totalLoopCount; i++)
+    {
+        auto [y1, x1] = getCoordinates(i, row, col);
+        auto [y2, x2] = getCoordinates((i + commandCount) % totalLoopCount, row, col);
+
+        rc[y2][x2] = prevArray[y1][x1];
+    }
+}
+
+void ExecuteShiftRowCommand(int commandCount, vector<vector<int>>& rc)
+{
+    int row = rc.size();
+    int col = rc[0].size();
+    // 본 코드 실패 후 이 코드를 추가하였지만 동일한 점수가 나옴.
+    if (row == commandCount)
+        return;
+
+    vector<vector<int>> prevArray = rc;
+
+    for (int i = 0; i < row; i++)
+    {
+        int index1 = i;
+        int index2 = (i + commandCount) % row;
+
+        rc[index2] = prevArray[index1];
+    }
+}
+
+vector<vector<int>> solution(vector<vector<int>> rc, vector<string> operations) {
+
+    string savedCommand = operations[0];
+    int commandCount = 1;
+    for (int i = 1; i <= operations.size(); i++)
+    {
+        if (i == operations.size() || savedCommand != operations[i])
+        {
+            if (savedCommand == SHIFT_ROW)
+                ExecuteShiftRowCommand(commandCount, rc);
+            else
+                ExecuteRotateCommand(commandCount, rc);
+
+            if (i < operations.size())
+            {
+                savedCommand = operations[i];
+                commandCount = 1;
+            }
+        }
+        else
+        {
+            commandCount++;
+        }
+    }
+
+    return rc;
+}
+
+
+///////////////////////////////////////
+///////// 첫 번째 풀이 실패 ////////////
+///////////////////////////////////////
+#include <string>
+#include <vector>
+
+using namespace std;
+
+const string SHIFT_ROW = "ShiftRow";
+const string ROTATE = "Rotate";
+
+// 인덱스에 대한 좌표 구하기.
+pair<int, int> getCoordinates(int i, int row, int col)
+{
+    int topCount = col;
+    int rightCount = row - 1;
+    int bottomCount = col - 1;
+    int leftCount = row - 2;
+
+    if (i < topCount)
+        return { 0, i };
+
+    i -= topCount;
+    if (i < rightCount)
+        return { i + 1, col - 1 };
+
+    i -= rightCount;
+    if (i < bottomCount)
+        return { row - 1, col - i - 2 };
+
+    i -= bottomCount;
+    if (i < leftCount)
+        return { row - 2 - i, 0 };
+
+    return { -1, -1 };
+}
+
+void ExecuteCommand(string command, vector<vector<int>>& rc)
+{
+    if (command == SHIFT_ROW)
+    {
+        vector<int> tempVec = rc[0];
+        vector<int> mySavedVec;
+
+        for (int i = 1; i < rc.size(); i++)
+        {
+            mySavedVec = rc[i];
+            rc[i] = tempVec;
+            tempVec = mySavedVec;
+        }
+
+        // rc의 0번에 마지막 데이터를 옮겨주는 작업 진행.
+        rc[0] = tempVec;
+    }
+    else
+    {
+        int row = rc.size();
+        int col = rc[0].size();
+
+        int temp = rc[0][0];
+        int savedMyValue;
+
+        int totalLoopCount = col * row - ((row - 2) * (col - 2));
+        for (int i = 1; i < totalLoopCount; i++)
+        {
+            auto [y, x] = getCoordinates(i, row, col);
+            savedMyValue = rc[y][x];
+            rc[y][x] = temp;
+            temp = savedMyValue;
+        }
+
+        rc[0][0] = temp;
+    }
+}
+
+vector<vector<int>> solution(vector<vector<int>> rc, vector<string> operations) {
+
+    for (string command : operations)
+    {
+        ExecuteCommand(command, rc);
+    }
+
+    return rc;
+}

--- a/Gombang/[LeetCode75] - [DFS]/1372_Longest_ZigZag_Path_in_a_Binary_Tree.cpp
+++ b/Gombang/[LeetCode75] - [DFS]/1372_Longest_ZigZag_Path_in_a_Binary_Tree.cpp
@@ -1,0 +1,48 @@
+/**
+ * Definition for a binary tree node.
+ * struct TreeNode {
+ *     int val;
+ *     TreeNode *left;
+ *     TreeNode *right;
+ *     TreeNode() : val(0), left(nullptr), right(nullptr) {}
+ *     TreeNode(int x) : val(x), left(nullptr), right(nullptr) {}
+ *     TreeNode(int x, TreeNode *left, TreeNode *right) : val(x), left(left), right(right) {}
+ * };
+ */
+class Solution {
+public:
+
+    const int LEFT = -1;
+    const int RIGHT = 1;
+
+    int answer = 0;
+
+    void dfs(TreeNode* root, int count, int direction)
+    {
+        if (root == nullptr)
+            return;
+
+        // 지금까지 저장된 가장 큰 answer값과 새로 들어온 count값의 크기 비교.
+        answer = max(answer, count + 1);
+
+        // 현재 노드로 들어오는 탐색 방향이 LEFT였다면,
+        if (direction == LEFT)
+        {
+            dfs(root->right, count + 1, RIGHT);
+            dfs(root->left, 0, LEFT); // 현재 노드에서부터 dfs를 다시 시작.
+        }
+        else
+        {
+            dfs(root->left, count + 1, LEFT);
+            dfs(root->right, 0, RIGHT); // 현재 노드에서부터 dfs를 다시 시작.
+        }
+    }
+
+    int longestZigZag(TreeNode* root) {
+
+        dfs(root->left, 0, LEFT);
+        dfs(root->right, 0, RIGHT);
+
+        return answer;
+    }
+};

--- a/Gombang/[LeetCode75] - [DFS]/236_Lowest_Common_Ancestor_of_a_Binary_Tree.cpp
+++ b/Gombang/[LeetCode75] - [DFS]/236_Lowest_Common_Ancestor_of_a_Binary_Tree.cpp
@@ -1,0 +1,76 @@
+// 모범 답안.
+
+class Solution {
+public:
+    TreeNode* lowestCommonAncestor(TreeNode* root, TreeNode* p, TreeNode* q) {
+        if (root == nullptr || root == p || root == q)
+            return root;
+
+        TreeNode* left = lowestCommonAncestor(root->left, p, q);
+        TreeNode* right = lowestCommonAncestor(root->right, p, q);
+
+        // left와 right둘다 nullptr가 아니라면 root가 조상 노드.
+        if (left != nullptr && right != nullptr)
+            return root;
+
+        return left != nullptr ? left : right;
+    }
+};
+
+
+
+// 첫번째 풀이 실패. testcase 29/32 Memory Limit Excceeded.
+
+class Solution {
+public:
+
+    void dfs(TreeNode* root, TreeNode* p, TreeNode* q, unordered_map<TreeNode*, vector<TreeNode*>>& map)
+    {
+        if (root == nullptr)
+            return;
+
+        // p와 q에 대해서 다 찾았다면,
+        if (map[p].size() > 0 && map[q].size() > 0)
+            return;
+
+        if (root->left != nullptr)
+        {
+            // 현재 노드의 조상노드가 담겨있는 벡터를 가져와서 left에 해당하는 노드를 추가한 후 업데이트.
+            vector<TreeNode*> currVec = map[root];
+            currVec.push_back(root->left);
+            map[root->left] = currVec;
+            dfs(root->left, p, q, map);
+        }
+
+        if (root->right != nullptr)
+        {
+            vector<TreeNode*> currVec = map[root];
+            currVec.push_back(root->right);
+            map[root->right] = currVec;
+            dfs(root->right, p, q, map);
+        }
+    }
+
+    TreeNode* lowestCommonAncestor(TreeNode* root, TreeNode* p, TreeNode* q) {
+
+        // map을 이용하여 각 노드마다 조상노드들을 구하도록 처리.
+        unordered_map<TreeNode*, vector<TreeNode*>> map;
+        map[root].push_back(root);
+
+        dfs(root, p, q, map);
+
+        vector<TreeNode*> ancestorPVec = map[p];
+        vector<TreeNode*> ancestorQVec = map[q];
+
+        for (int i = ancestorPVec.size() - 1; i >= 0; i--)
+        {
+            for (int j = ancestorQVec.size() - 1; j >= 0; j--)
+            {
+                if (ancestorPVec[i] == ancestorQVec[j])
+                    return ancestorPVec[i];
+            }
+        }
+
+        return nullptr;
+    }
+};


### PR DESCRIPTION
# 25년 11주차 TIL

## 1. Longest ZigZag Path in a Binary Tree (LeetCode 1372)

- 지그재그 규칙으로 트리의 노드를 방문한다고 했을 때 지그재그의 길이 중, 가장 긴 길이를 반환하는 문제였다. 특별히 어려웠던 점은 없었다.

## 2. Lowest Common Ancestor of a Binary Tree (LeetCode 236)

- p와 q노드에 대해서 공통된 조상 노드 중 가장 깊은 조상 노드를 찾는 문제였다. 

- 처음에 풀이했던 방법은 map을 이용하여 dfs순회를 하면서 각 노드들에 대해 조상노드들을 계속 구해가는 과정을 진행하고 최종적으로 p와 q에 대한 조상노드들을 모두 찾았으면 공통된 조상 노드를 반환하도록 처리하였다. 하지만, 해당 풀이 방법은 모든 노드들에 대해서 조상노드를 찾게 되다 보니 메모리 초과 에러가 나게 되었다. 

- 루시님의 풀이를 참고하여 다시 생각해보니 모든 노드들에 대해서 조상노드를 저장해둘 필요 없이, p와 q에 대해서만 조상노드를 찾으면 되므로 map에 모든 노드에 대한 조상 노드 데이터를 저장하는 것이 아니라 차라리 depth가 들어갈수록 이전 map에 대한 데이터를 초기화해준다거나 하는 방식으로 했으면 메모리 에러는 피할 수 있지 않았을까? 하는 생각이 들었다.

## 3. 행렬과 연산 ( kakao 2022 )

- 해당 문제는 주어진 행렬에 ShiftRow라는 연산과 Rotate라는 연산을 수행했을 때 나오는 결과를 반환하는 문제였다.

- 문제를 이해하는데에는 큰 어려움이 없었으나 정확성과 효율성을 따지는 문제였기에 어떻게 하면 효율적으로 문제를 풀 수 있을지에 대한 고민을 많이 하게 되었다. 

- 처음에는 마땅한 아이디어가 떠오르지 않아 단순하게 주어진 방식대로 ShiftRow연산과 Rotate라는 연산을 직접 구현하면서 진행해보았다. 정확성은 모두 통과하였으나 당연하게도 효율성은 모두 실패하게 되었다.

- 두 번째로 시도한 방법은 주어진 연산들을 하나하나 처리하기 보다는 연속적으로 공통된 연산이 진행될 경우 한 번에 묶어서 처리하는 방법을 시도해보았다. 이 방식으로 진행했을 때는 효율성 테스트 중 3개를 실패하게 되었다.

- 더 이상 효율적인 방법을 찾아내지 못해, 카카오 해설을 참고하며 여러 해설 글들을 보고 풀이를 진행하게 되었다. 이 문제의 핵심은 각 연산(ShiftRow, Rotate)들을 O(1)로 처리를 꼭 진행해야 하는 문제였다. 왜냐하면, 제한사항에 행렬의 크기가 최대 100,000이고 주어지는 연산의 최대 개수도 100,000이기 때문에 일일이 행렬을 진행하게 되면 최대 10^10에 대한 연산이 진행되기 때문이다. 

- 따라서, 각 연산을 O(1)로 실행되기 위해서 어떤 방법을 사용할 수 있는지를 알아보니, Deque를 이용하는 방법을 알게 되었다. Deque의 경우 양쪽 끝에서 삽입, 삭제가 일어날 수 있는 자료구조 이기에, 행렬을 여러개의 Deque로 쪼개서 push_front, push_back, pop_front, pop_back 을 이용하여 구현하면 되는 문제였다. 

- 개인적으로 문제를 풀기 위해서 색다른 아이디어를 생각해내야 된다는 점에 있어서 좋은 문제였다고 생각한다.