### PR TITLE
[프로그래머스+LeetCode 75] [Seori] 25년 14주차 3문제 풀이

### DIFF
--- a/Seori/LeetCode 75/Graph_DFS/547. Number of Provinces.py
+++ b/Seori/LeetCode 75/Graph_DFS/547. Number of Provinces.py
@@ -1,0 +1,21 @@
+class Solution:
+    def findCircleNum(self, isConnected: List[List[int]]) -> int:
+        
+        def dfs(now: int) -> None:
+            for next in range(n):
+                if isConnected[now][next] == 1 and not visited[next]:
+                    visited[next] = 1
+                    dfs(next)
+
+        n = len(isConnected)
+        visited = [0] * n
+        
+        # 1번 도시부터 DFS 탐색을 실시한다. 다른 도시와 연결되지 않은 경우에만 is_province가 증가한다.
+        is_province = 0
+        for i in range(n):
+            if not visited[i]:
+                visited[i] = 1
+                dfs(i)
+                is_province += 1
+
+        return is_province

--- a/Seori/LeetCode 75/Graph_DFS/841. Keys and Rooms.py
+++ b/Seori/LeetCode 75/Graph_DFS/841. Keys and Rooms.py
@@ -1,0 +1,16 @@
+class Solution:
+    def canVisitAllRooms(self, rooms: List[List[int]]) -> bool:
+        
+        def dfs(now: int, rooms: List[List[int]]) -> None:
+            visited[now] = 1
+            for next in rooms[now]:
+                if next < n and not visited[next]:
+                    dfs(next, rooms)
+        
+        # [1] DFS로 0번방부터 탐색
+        n = len(rooms)
+        visited = [0] * n
+        dfs(0, rooms)
+
+        # [2] 모든 방에 방문했다면 True
+        return sum(visited) == n

--- a/Seori/Programmers/사라지는 발판.py
+++ b/Seori/Programmers/사라지는 발판.py
@@ -1,0 +1,46 @@
+def solution(board, aloc, bloc):
+
+    direction = [(0, -1), (-1, 0), (1, 0), (0, 1)]
+    
+    def dfs(board, my_loc, your_loc, turn):
+        # [1] 재귀 종료 조건. 지금 내 발판이 0인 경우 패배 확정이다.
+        x, y = my_loc
+        if board[x][y] == 0:
+            return turn, 0
+        
+        # [2] 4방향을 탐색하며 가능한 경우 재귀를 시작한다.
+        winner = False
+        max_move = 0
+        min_move = float('inf')
+        for dx, dy in direction:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < len(board) and 0 <= ny < len(board[0]) and board[nx][ny] == 1:
+                
+                # [3] 움직이기 위해 지금 발판을 0처리 해주고,
+                board[x][y] = 0
+                loser, move = dfs(board, your_loc, [nx, ny], not turn) # 재귀를 할 땐 플레이어 순서를 바꿔준다.
+                # [4] 재귀 탐색이 끝나면 발판을 다시 1 처리해준다.(백트래킹)
+                board[x][y] = 1
+                
+                # [5] 지금이 진 사람의 턴이라면 최대한 오래 버티도록 플레이
+                if turn == loser:
+                    max_move = max(max_move, move + 1)
+                # [6] 지금이 이긴 사람의 턴이라면 최대한 빨리 이기도록 플레이
+                else:
+                    winner = True
+                    min_move = min(min_move, move + 1)
+        
+        
+        # [7] 승/패에 맞게 움직임 횟수를 반환
+        if winner:
+            return (not turn, min_move)
+        else:
+            return (turn, max_move)
+    
+    return dfs(board, aloc, bloc, False)[1]
+
+# Test case 1
+board = [[1, 1, 1], [1, 1, 1], [1, 1, 1]]
+aloc = [1, 0]
+bloc = [1, 2]
+print(solution(board, aloc, bloc))  # Expected output: 5

--- a/Seori/TIL/25년 14주차 TIL.md
+++ b/Seori/TIL/25년 14주차 TIL.md
@@ -1,0 +1,117 @@
+# 25년 14주차 TIL
+
+## 1. Keys and Rooms(LeetCode 841)
+
+그래프의 `DFS` 유형 문제의 기본 형태이다. 각 방에 주어진 그래프 연결 관계를 활용해서, 특정 방에 방문하였는지 `visited`에 기록하고 정답을 도출했다.
+
+### 풀이
+
+```python
+class Solution:
+    def canVisitAllRooms(self, rooms: List[List[int]]) -> bool:
+
+        def dfs(now: int, rooms: List[List[int]]) -> None:
+            visited[now] = 1
+            for next in rooms[now]:
+                if next < n and not visited[next]:
+                    dfs(next, rooms)
+
+        # [1] DFS로 0번방부터 탐색
+        n = len(rooms)
+        visited = [0] * n
+        dfs(0, rooms)
+
+        # [2] 모든 방에 방문했다면 True
+        return sum(visited) == n
+```
+
+## 2. Number of Provinces**(LeetCode** 547**)**
+
+풀이가 위 문제와 크게 다르지 않았다.
+
+방문 여부를 `visited` 리스트로 기록하고, 이번에는 연결 관계가 문제에서 인접 리스트 방식으로 주어졌으나 풀이 자체는 동일하게 `dfs` 메서드가 도시에 방문한다는 개념으로 작성하여 풀이했다.
+
+모범답안을 통해 `visited` 리스트의 인덱스로 비교하는 것보다는 `set`으로 만들어 A in visited 비교를 하는 것이 시간적으로 더 효율적이라는 결론을 내렸다.
+
+### 풀이
+
+```python
+class Solution:
+    def findCircleNum(self, isConnected: List[List[int]]) -> int:
+
+        def dfs(now: int) -> None:
+            for next in range(n):
+                if isConnected[now][next] == 1 and not visited[next]:
+                    visited[next] = 1
+                    dfs(next)
+
+        n = len(isConnected)
+        visited = [0] * n
+
+        # 1번 도시부터 DFS 탐색을 실시한다. 다른 도시와 연결되지 않은 경우에만 is_province가 증가한다.
+        is_province = 0
+        for i in range(n):
+            if not visited[i]:
+                visited[i] = 1
+                dfs(i)
+                is_province += 1
+
+        return is_province
+```
+
+## 3. 사라지는 발판(Programmers 카카오 2022)
+
+다 와서 너무 헤맸던 문제.. 주어지는 보드판의 범위가 크지 않고, 경우의 수 안에서 최적의 해를 구해야 하므로 완전탐색이 필요한 문제라고 알아차려야 했다.
+
+`dfs` 메서드를 정의하면서 4번째 파라미터인 `turn`을 `True` 혹은 `False`로 받을 수 있게 하고, 이번 턴에 패배한 경우에 반환하도록 작성하면서 지금 차례가 승자인지 패자인지를 알 수 있게 구성했다.
+
+풀이하며 헤맸던 곳은 [7] 부분이었다. 위에서는 패자를 반환하도록 구성해놓고서, [7]에서는 그 개념을 헷갈려서 내가 `winner`인 경우 `False`를 반환한다고 해버려서 자꾸 틀리는 경우가 발생했었다.
+
+우여곡절은 많았으나 결국 완전탐색 유형이었으므로 구현하고 나면 풀이가 비슷했던 문제였다.
+
+### 풀이
+
+```python
+def solution(board, aloc, bloc):
+
+    direction = [(0, -1), (-1, 0), (1, 0), (0, 1)]
+
+    def dfs(board, my_loc, your_loc, turn):
+        # [1] 재귀 종료 조건. 지금 내 발판이 0인 경우 패배 확정이다.
+        x, y = my_loc
+        if board[x][y] == 0:
+            return turn, 0
+
+        # [2] 4방향을 탐색하며 가능한 경우 재귀를 시작한다.
+        winner = False
+        max_move = 0
+        min_move = float('inf')
+        for dx, dy in direction:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < len(board) and 0 <= ny < len(board[0]) and board[nx][ny] == 1:
+
+                # [3] 움직이기 위해 지금 발판을 0처리 해주고,
+                board[x][y] = 0
+                loser, move = dfs(board, your_loc, [nx, ny], not turn) # 재귀를 할 땐 플레이어 순서를 바꿔준다.
+                # [4] 재귀 탐색이 끝나면 발판을 다시 1 처리해준다.(백트래킹)
+                board[x][y] = 1
+
+                # [5] 지금이 진 사람의 턴이라면 최대한 오래 버티도록 플레이
+                if turn == loser:
+                    max_move = max(max_move, move + 1)
+                # [6] 지금이 이긴 사람의 턴이라면 최대한 빨리 이기도록 플레이
+                else:
+                    winner = True
+                    min_move = min(min_move, move + 1)
+
+
+        # [7] 승/패에 맞게 움직임 횟수를 반환
+        if winner:
+            # return (False, min_move)
+            return (not turn, min_move)
+        else:
+            # return (True, min_move)
+            return (turn, max_move)
+
+    return dfs(board, aloc, bloc, False)[1]
+```


### PR DESCRIPTION
# 25년 14주차 TIL

## 1. Keys and Rooms(LeetCode 841)

그래프의 `DFS` 유형 문제의 기본 형태이다. 각 방에 주어진 그래프 연결 관계를 활용해서, 특정 방에 방문하였는지 `visited`에 기록하고 정답을 도출했다.

### 풀이

```python
class Solution:
    def canVisitAllRooms(self, rooms: List[List[int]]) -> bool:

        def dfs(now: int, rooms: List[List[int]]) -> None:
            visited[now] = 1
            for next in rooms[now]:
                if next < n and not visited[next]:
                    dfs(next, rooms)

        # [1] DFS로 0번방부터 탐색
        n = len(rooms)
        visited = [0] * n
        dfs(0, rooms)

        # [2] 모든 방에 방문했다면 True
        return sum(visited) == n
```

## 2. Number of Provinces**(LeetCode** 547**)**

풀이가 위 문제와 크게 다르지 않았다.

방문 여부를 `visited` 리스트로 기록하고, 이번에는 연결 관계가 문제에서 인접 리스트 방식으로 주어졌으나 풀이 자체는 동일하게 `dfs` 메서드가 도시에 방문한다는 개념으로 작성하여 풀이했다.

모범답안을 통해 `visited` 리스트의 인덱스로 비교하는 것보다는 `set`으로 만들어 A in visited 비교를 하는 것이 시간적으로 더 효율적이라는 결론을 내렸다.

### 풀이

```python
class Solution:
    def findCircleNum(self, isConnected: List[List[int]]) -> int:

        def dfs(now: int) -> None:
            for next in range(n):
                if isConnected[now][next] == 1 and not visited[next]:
                    visited[next] = 1
                    dfs(next)

        n = len(isConnected)
        visited = [0] * n

        # 1번 도시부터 DFS 탐색을 실시한다. 다른 도시와 연결되지 않은 경우에만 is_province가 증가한다.
        is_province = 0
        for i in range(n):
            if not visited[i]:
                visited[i] = 1
                dfs(i)
                is_province += 1

        return is_province
```

## 3. 사라지는 발판(Programmers 카카오 2022)

다 와서 너무 헤맸던 문제.. 주어지는 보드판의 범위가 크지 않고, 경우의 수 안에서 최적의 해를 구해야 하므로 완전탐색이 필요한 문제라고 알아차려야 했다.

`dfs` 메서드를 정의하면서 4번째 파라미터인 `turn`을 `True` 혹은 `False`로 받을 수 있게 하고, 이번 턴에 패배한 경우에 반환하도록 작성하면서 지금 차례가 승자인지 패자인지를 알 수 있게 구성했다.

풀이하며 헤맸던 곳은 [7] 부분이었다. 위에서는 패자를 반환하도록 구성해놓고서, [7]에서는 그 개념을 헷갈려서 내가 `winner`인 경우 `False`를 반환한다고 해버려서 자꾸 틀리는 경우가 발생했었다.

우여곡절은 많았으나 결국 완전탐색 유형이었으므로 구현하고 나면 풀이가 비슷했던 문제였다.

### 풀이

```python
def solution(board, aloc, bloc):

    direction = [(0, -1), (-1, 0), (1, 0), (0, 1)]

    def dfs(board, my_loc, your_loc, turn):
        # [1] 재귀 종료 조건. 지금 내 발판이 0인 경우 패배 확정이다.
        x, y = my_loc
        if board[x][y] == 0:
            return turn, 0

        # [2] 4방향을 탐색하며 가능한 경우 재귀를 시작한다.
        winner = False
        max_move = 0
        min_move = float('inf')
        for dx, dy in direction:
            nx, ny = x + dx, y + dy
            if 0 <= nx < len(board) and 0 <= ny < len(board[0]) and board[nx][ny] == 1:

                # [3] 움직이기 위해 지금 발판을 0처리 해주고,
                board[x][y] = 0
                loser, move = dfs(board, your_loc, [nx, ny], not turn) # 재귀를 할 땐 플레이어 순서를 바꿔준다.
                # [4] 재귀 탐색이 끝나면 발판을 다시 1 처리해준다.(백트래킹)
                board[x][y] = 1

                # [5] 지금이 진 사람의 턴이라면 최대한 오래 버티도록 플레이
                if turn == loser:
                    max_move = max(max_move, move + 1)
                # [6] 지금이 이긴 사람의 턴이라면 최대한 빨리 이기도록 플레이
                else:
                    winner = True
                    min_move = min(min_move, move + 1)


        # [7] 승/패에 맞게 움직임 횟수를 반환
        if winner:
            # return (False, min_move)
            return (not turn, min_move)
        else:
            # return (True, min_move)
            return (turn, max_move)

    return dfs(board, aloc, bloc, False)[1]
```
