### PR TITLE
[프로그래머스+LeetCode 75] [Gombang] 25년 15주차 3문제 풀이

### DIFF
--- a/Gombang/Programmers/파괴되지 않은 건물.cpp
+++ b/Gombang/Programmers/파괴되지 않은 건물.cpp
@@ -1,0 +1,45 @@
+#include <string>
+#include <vector>
+
+using namespace std;
+
+int sumArray[1010][1010];
+int N, M;
+
+int solution(vector<vector<int>> board, vector<vector<int>> skill) {
+    N = board.size(), M = board[0].size();
+
+    for (auto sk : skill) {
+        int degree = sk[5];
+        if (sk[0] == 1) degree = -degree;
+
+        sumArray[sk[1]][sk[2]] += degree;
+        sumArray[sk[3] + 1][sk[4] + 1] += degree;
+        sumArray[sk[1]][sk[4] + 1] -= degree;
+        sumArray[sk[3] + 1][sk[2]] -= degree;
+    }
+
+    // 왼쪽에서 오른쪽으로 누적합을 구하는 과정.
+    for (int i = 0; i < N + 1; ++i) {
+        for (int j = 0; j < M; ++j) {
+            sumArray[i][j + 1] += sumArray[i][j];
+        }
+    }
+
+    // 위에서 아래로 누적합을 구하는 과정.
+    for (int j = 0; j < M + 1; ++j) { 
+        for (int i = 0; i < N; ++i) {
+            sumArray[i + 1][j] += sumArray[i][j];
+        }
+    }
+
+    // 최종적으로 보드에 대해 sumArray적용.
+    int answer = 0;
+    for (int i = 0; i < N; ++i) { 
+        for (int j = 0; j < M; ++j) {
+            if (board[i][j] + sumArray[i][j] > 0) answer++;
+        }
+    }
+
+    return answer;
+}

--- a/Gombang/[LeetCode75] - [DFS]/1466_Reorder_Routes_to_Make_All_Paths_Lead_to_the_City_Zero.cpp
+++ b/Gombang/[LeetCode75] - [DFS]/1466_Reorder_Routes_to_Make_All_Paths_Lead_to_the_City_Zero.cpp
@@ -1,0 +1,65 @@
+class Solution {
+public:
+
+    unordered_map<int, vector<int>> twoWayRoadGraph;
+    unordered_map<int, vector<int>> originalRoadGraph;
+
+    void dfs(int currCity, vector<bool>& canMoveToCityZeroVec, int& changeCount)
+    {
+        vector<int> adjCities = originalRoadGraph[currCity];
+        for (int i = 0; i < adjCities.size(); i++)
+        {
+            // 나와 인접한 도시를 통해서 0번 도시로 갈 수 있으면, 나의 도시도 0번 도시로 갈 수 있다.
+            if (canMoveToCityZeroVec[adjCities[i]])
+            {
+                canMoveToCityZeroVec[currCity] = true;
+                break;
+            }
+        }
+
+        // 위 for루프를 돌렸음에도 나의 도시에서 0번 도시로 갈 수 없다면 true로 바꿔주고 카운트+1증가.
+        if (canMoveToCityZeroVec[currCity] == false)
+        {
+            canMoveToCityZeroVec[currCity] = true;
+            changeCount++;
+        }
+
+        vector<int> nextCityList = twoWayRoadGraph[currCity];
+        for (int nextCity : nextCityList)
+        {
+            if (canMoveToCityZeroVec[nextCity] == false)
+            {
+                dfs(nextCity, canMoveToCityZeroVec, changeCount);
+            }
+        }
+    }
+
+    int minReorder(int n, vector<vector<int>>& connections) {
+
+        // 양방향 그래프를 통해
+        for (int i = 0; i < connections.size(); i++)
+        {
+            int startNode = connections[i][0];
+            int endNode = connections[i][1];
+
+            twoWayRoadGraph[startNode].push_back(endNode);
+            twoWayRoadGraph[endNode].push_back(startNode);
+
+            originalRoadGraph[startNode].push_back(endNode);
+        }
+
+        int changeCount = 0;
+        vector<bool> canMoveToCityZeroVec(n, false);
+        canMoveToCityZeroVec[0] = true;
+
+        // 0번 도시를 시작으로 twoWayGraph를 참고하여 dfs순회를 하며 
+        // currRoadGraph에 0으로 가는 것이 없다면 카운팅을 + 1한다.
+        vector<int> cities = twoWayRoadGraph[0];
+        for (int i = 0; i < cities.size(); i++)
+        {
+            dfs(cities[i], canMoveToCityZeroVec, changeCount);
+        }
+
+        return changeCount;
+    }
+};

--- a/Gombang/[LeetCode75] - [DFS]/399_Evaluate_Division.cpp
+++ b/Gombang/[LeetCode75] - [DFS]/399_Evaluate_Division.cpp
@@ -1,0 +1,54 @@
+class Solution {
+public:
+    unordered_map<string, unordered_map<string, double>> graph;
+
+    double dfs(const string& start, const string& end, unordered_set<string>& visited) 
+    {
+        if (start == end)
+            return 1.0;
+
+        for (auto t : graph[start]) 
+        {
+            string middleNode = t.first;
+            double val = t.second;
+
+            if (visited.contains(middleNode))
+                continue;
+  
+            visited.insert(start);
+
+            double result = dfs(middleNode, end, visited);
+            if (result != -1.0)
+                return val * result;
+        }
+
+        return -1.0;
+    }
+
+    vector<double> calcEquation(vector<vector<string>>& equations, vector<double>& values, vector<vector<string>>& queries)
+    {
+        vector<double> result;
+
+        for (int i = 0; i < equations.size(); i++)
+        {
+            graph[equations[i][0]][equations[i][1]] = values[i];
+            graph[equations[i][1]][equations[i][0]] = 1 / values[i];
+        }
+
+        for (auto& q : queries) 
+        {
+            if (graph.contains(q[0]) == false || 
+                graph.contains(q[1]) == false) 
+            {
+                result.push_back(-1.0);
+                continue;
+            }
+
+            unordered_set<string> visited;
+            result.push_back(findPath(q[0], q[1], visited));
+        }
+
+        return result;
+    }
+
+};


### PR DESCRIPTION
# 25년 15주차 TIL

## 1. Reorder Routes to Make All Paths Lead to the City Zero (LeetCode 1466)

- 이 문제는 다른 도시들도 0번 지역으로 이동할 수 있도록 연결된 도로의 방향을 바꿔주는 문제였다. 

- 풀이했던 방법은 0번부터 도시를 dfs로 순회하며, 순회할 때마다 0번 도시로 이동할 수 있다는 bool변수를 true로 바꿔주는 방식으로 풀이하였다.

- 두 개의 Map자료구조를 이용하여, 하나는 0번 도시부터 dfs로 순회하기 위한 양방향 그래프(twoWayRoadGraph)를 만들어주었고, 다른 하나는 기존의 도로를 의미하는 단방향 그래프(originalRoadGraph)로 만들어주었다. 그리고 canMoveToCityZeroVec이라는 변수를 만들어주었는데, 이는 현재 도시에서 0번 도시로 갈 수 있는가? 를 나타내는 변수이다.

- 단방향 그래프(originalRoadGraph)를 통해 나의 주변에 있는 도시들을 참고하여 0번 도시로 갈 수 있는지를 체크하는 과정이 존재하는데 이는 효율적이지 못한 풀이법이라는 것이 확연히 눈에 들어오게되어 풀이를 마치고 다른 풀이법을 확인해보았다. union-find알고리즘 풀이법을 확인하였고 또한, 알고리즘 발표 시간에 루시님의 코드를 확인해보니 방향에 대한 정보를 같이 넣어서 풀이하는 방법도 있음을 알게 되었다.

## 2. Evaluate Division (LeetCode 399)

- 이 문제는 어떻게 풀어야 할 지 아예 감이 잡히지 않아, 이것저것 끄적여보다가 풀이법도 확인해보았는데 왜 이게 dfs문제인지 정확히 이해하지 못했었다. 하지만, 알고리즘 발표 시간에 루시님의 그림을 보니 dfs문제라는 것을 확실히 이해할 수 있었다.

- 양방향 그래프를 만들어 정방향으로 갈때는 가중치를 수치값 그대로, 역방향으로 갈 때는 그래프의 가중치를 역수로 표현해주고 차례대로 dfs처리를 해주면서 만나는 가중치들을 곱해만주면 풀이되는 문제였다. 처음으로 본 신기한 dfs문제였다.

## 3. 파괴되지 않은 건물 (2022 KAKAO BLIND RECRUITMENT)

- 이 문제는 주어지는 보드의 크기와 스킬의 크기가 너무 커, 주어진대로 격자 하나씩 데미지 및 회복 스킬을 적용시키면 효율성에서 통과되지 못하는 문제이다. 어떻게 하면 효율적으로 할 수 있을까?에 대해서 아무리 고민해봐도 떠오르지 않아 이 문제도 알고리즘 발표 시간에 풀이법을 알게 되었다. 

- IMOS알고리즘에 대해서 알게 되었는데, 하나하나 적용하는 방식이 아닌 시작점과 끝점에 대해서만 설정해준 뒤 마지막에 한 번의 반복만을 통해 답을 얻어내는 방식이다.